### PR TITLE
Updated phi-finder to 0.1.14.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           # - mri/human/neuro/bidsapps/fmriprep
           # - mri/human/neuro/bidsapps/mriqc
           # - mri/human/neuro/bidsapps/smriprep
-          - mri/human/neuro/t1w/preprocess
+          # - mri/human/neuro/t1w/preprocess
     steps:
     - name: Removed unnecessary tools to free space
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           # - mri/human/neuro/bidsapps/fmriprep
           # - mri/human/neuro/bidsapps/mriqc
           # - mri/human/neuro/bidsapps/smriprep
-          #- mri/human/neuro/t1w/preprocess
+          - mri/human/neuro/t1w/preprocess
     steps:
     - name: Removed unnecessary tools to free space
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           # - mri/human/neuro/bidsapps/fmriprep
           # - mri/human/neuro/bidsapps/mriqc
           # - mri/human/neuro/bidsapps/smriprep
-          - mri/human/neuro/t1w/preprocess
+          #- mri/human/neuro/t1w/preprocess
     steps:
     - name: Removed unnecessary tools to free space
       run: |

--- a/specs/australian-imaging-service/quality-control/phi-finder.yaml
+++ b/specs/australian-imaging-service/quality-control/phi-finder.yaml
@@ -1,6 +1,6 @@
 schema_version: '2.0'
 title: PHI-Finder
-version: 0.1.14
+version: &package_version "0.1.14"
 authors:
   - name: Pedro Faustini
     email: pedro.faustini@mq.edu.au

--- a/specs/australian-imaging-service/quality-control/phi-finder.yaml
+++ b/specs/australian-imaging-service/quality-control/phi-finder.yaml
@@ -1,6 +1,6 @@
 schema_version: '2.0'
 title: PHI-Finder
-version: 0.1.13
+version: 0.1.14
 authors:
   - name: Pedro Faustini
     email: pedro.faustini@mq.edu.au
@@ -24,7 +24,7 @@ packages:
   conda:
     tesseract: 5.5.0
   pip:
-    phi-finder: 0.1.13
+    phi-finder: *package_version
     torch:
     thinc:
 commands:


### PR DESCRIPTION
use_case argument when launching phi-finder supports the guidelines from Dicom PS3.15 Attribute Confidentiality Profiles (link in the end).

When use_case is set to "PS3.15", the (standard) headers are de-identified with the DICOM PS3.15 guidelines. This approach gets rid of age, gender, weight.

When it is set to "PS3.15_Rtn. Pat.", the Retain Patient Characteristics guideline is applied (which retains things like gender, age, weight).

See guidelines table in https://dicom.nema.org/medical/dicom/current/output/chtml/part15/chapter_E.html