### PR TITLE
MONAI Model Zoo → pipeline2app spec generator

### DIFF
--- a/.github/workflows/monai-sync.yml
+++ b/.github/workflows/monai-sync.yml
@@ -1,0 +1,34 @@
+name: Sync MONAI model specs
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"   # 03:00 UTC every Monday
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: monai-test
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+      - name: Generate/update MONAI specs
+        run: python -m scripts.monai_specs sync
+      - name: Open PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: monai-spec-sync
+          base: monai-test
+          title: "Update MONAI model specs"
+          commit-message: "chore(monai): sync model specs from Model Zoo"
+          body: "Automated MONAI Model Zoo spec sync. Review generated specs and task modules before merge."
+          add-paths: |
+            specs/**/monai/**
+            src/australianimagingservice/**/monai/**

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test-data
 *.build*
 *.venv
 _version.py
+.monai-bundles

--- a/docs/superpowers/plans/2026-07-10-monai-model-registry.md
+++ b/docs/superpowers/plans/2026-07-10-monai-model-registry.md
@@ -4,18 +4,20 @@
 
 **Goal:** Add a `MonaiModels` generator (in `scripts/`) that fetches MONAI Model Zoo bundles, filters by a whitelist, detects version changes, generates pipeline2app XNAT specs (using `pydra-compose-monai`), and writes them into a `monai/` spec namespace — driven by a scheduled GitHub Action that opens a PR.
 
-**Architecture:** A single orchestrator class `MonaiModels` with focused, independently-testable methods (fetch → filter → detect → generate → write → sync). MONAI→fileformats field serialization is delegated to `pydra_compose_monai.spec_fragment`; catalog/build metadata comes from a hand-authored per-model overlay deep-merged with the fragment. Generated specs are `pydra2app`/`pipeline2app` 2.x `XnatApp` specs.
+**Architecture:** A single orchestrator class `MonaiModels` with focused, independently-testable methods (fetch → filter → detect → generate → write → sync). MONAI→fileformats field serialization is delegated to `pydra_compose_monai.spec_fragment`; catalog/build metadata comes from a hand-authored per-model overlay deep-merged with the fragment. For each model the generator also emits a committed, importable per-model task module (a `define()`-built `MonaiTask` subclass with the baked-in bundle path) that the spec's `command.task` references by dotted path. Generated specs are `pydra2app`/`pipeline2app` 2.x `XnatApp` specs.
 
 **Tech Stack:** Python ≥3.8, PyYAML, monai.bundle, pydra-compose-monai (from PyPI), pydra2app/pydra2app-xnat, pytest. Work lands on the existing `monai-test` branch.
 
+> **Design decision (Option A, 2026-07-24):** `command.task` points at a **committed generated per-model class** (`australianimagingservice…monai.<model>:<Class>`), NOT a generic `pydra.compose.monai:BundleTask`. Reason: the raw `MonaiTask` base has no usable fields and cannot be instantiated with `bundle=`; only a `define()`-built subclass can. The module-reference form is pipeline2app's primary, best-tested `task` path (identical to how the existing FSL/FastSurfer specs work), is reviewable as real Python in the sync PR, and avoids a per-container-launch `define()` call. (The inline task-dict form was verified against source to also work, but re-adds a runtime `define()` and a field-serialization surface, so it was not chosen.)
+
 ## Global Constraints
 
-- Depends on **`pydra-compose-monai`** providing `spec_fragment()` and `BundleTask` (Plan `2026-07-10-monai-spec-fragment.md` in the pydra-compose-monai repo). That must ship first; add `pydra-compose-monai` to the `test` deps of `pyproject.toml`.
-- `requires-python >=3.8` (repo target) — this repo targets py38, so **use `Optional[...]`/`Dict[...]` typing imports, NOT `X | Y` syntax**, in `scripts/`.
+- Depends on **`pydra-compose-monai`** providing `spec_fragment()` (Plan `2026-07-10-monai-spec-fragment.md` in the pydra-compose-monai repo, PR #12). That must ship / be installable first; add `pydra-compose-monai` to the `test` deps of `pyproject.toml`. NOTE: `BundleTask` was dropped from that plan — do not reference it.
+- `requires-python >=3.8` (repo target) — this repo targets py38, so **use `Optional[...]`/`Dict[...]` typing imports, NOT `X | Y` syntax**, in `scripts/`. (The *generated* task modules import from `pydra.compose.monai`, which requires 3.11 — that is fine because they only ever run inside the built image, not under the repo's py38 floor.)
 - Generated specs target the **pydra2app/pipeline2app 2.x schema** consumed by `XnatApp.load(...)` (see `tests/test_monai.py`): top-level `commands:` is a **list**; per-command keys `task`, `operates_on`, `sources`, `sinks`, `parameters`, `configuration`.
-- `command.task` = `"pydra.compose.monai:BundleTask"`; bundle fixed via `configuration: {bundle: /opt/bundles/<model>}`.
+- `command.task` = the dotted ref of the generated per-model class: `"australianimagingservice.<modality>.<species>.<region>.monai.<model>:<ClassName>"`. The class is a `define()`-built `MonaiTask` subclass whose `bundle` defaults to the baked-in path `/opt/bundles/<model>`. No `configuration.bundle` is needed (the default is baked into the class), so `configuration` is `{}`.
 - Datatypes are fileformats MIME-like strings.
-- Generator lives in top-level `scripts/` (already excluded from mypy/package in `pyproject.toml`). Tests live in `tests/`.
+- Generator lives in top-level `scripts/` (already excluded from mypy/package in `pyproject.toml`). Tests live in `tests/`. Generated task modules live in the installable package under `src/australianimagingservice/<modality>/<species>/<region>/monai/`.
 - Generated specs written under `specs/australian-imaging-service/<modality>/<species>/<region>/monai/<model>.yaml`.
 - The Action opens a **PR**, never pushes to a protected branch directly.
 
@@ -24,6 +26,7 @@
 - `scripts/monai_specs.py` — `MonaiModels` class + a `__main__` entry point (`python -m scripts.monai_specs sync`).
 - `scripts/monai_whitelist.yaml` — control surface: models, optional version pins, anatomy placement.
 - `scripts/overlays/<model>.yaml` — per-model hand-authored catalog/build metadata.
+- `src/australianimagingservice/<modality>/<species>/<region>/monai/<model>.py` — generated, committed per-model task class (`define()`-built) referenced by `command.task`.
 - `tests/test_monai_specs.py` — unit tests for each method against synthetic bundles.
 - `.github/workflows/monai-sync.yml` — scheduled sync Action.
 
@@ -413,7 +416,149 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 4: Generate a full spec (fragment + overlay merge)
+### Task 4: Naming/module-path helpers + generate the per-model task module
+
+**Files:**
+- Modify: `scripts/monai_specs.py`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: `WhitelistEntry` (Task 1); `self.root`.
+- Produces:
+  ```python
+  def class_name(self, entry: WhitelistEntry) -> str:      # CamelCase, e.g. SpleenCtSegmentation
+  def task_module_path(self, entry: WhitelistEntry) -> Path:
+      # <root>/src/australianimagingservice/<modality>/<species>/<region>/monai/<model>.py
+  def task_module_ref(self, entry: WhitelistEntry) -> str:
+      # "australianimagingservice.<modality>.<species>.<region>.monai.<model>:<ClassName>"
+  def write_task_module(self, entry: WhitelistEntry) -> Path:
+      # writes the generated .py (define()-built class, baked-in bundle path), returns path
+  ```
+- The generated module baked-bundle path is `/opt/bundles/<model>` (`BAKED_BUNDLE_ROOT`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+def test_class_name_is_camelcase(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.class_name(entry) == "SpleenCtSegmentation"
+
+
+def test_task_module_ref_and_path(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.task_module_ref(entry) == (
+        "australianimagingservice.ct.human.abdomen.monai."
+        "spleen_ct_segmentation:SpleenCtSegmentation"
+    )
+    assert mm.task_module_path(entry) == (
+        tmp_path / "src" / "australianimagingservice" / "ct" / "human"
+        / "abdomen" / "monai" / "spleen_ct_segmentation.py"
+    )
+
+
+def test_write_task_module_emits_importable_define_call(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    path = mm.write_task_module(entry)
+    assert path == mm.task_module_path(entry)
+    text = path.read_text()
+    # references pydra-compose-monai define, bakes the bundle path, names the class
+    assert "from pydra.compose import monai" in text
+    assert '"/opt/bundles/spleen_ct_segmentation"' in text
+    assert "SpleenCtSegmentation = monai.define(" in text
+    # every generated package dir has an __init__.py so the dotted ref imports
+    assert (path.parent / "__init__.py").is_file()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/gbro5457/code/pipelines && .venv/bin/pytest tests/test_monai_specs.py -k "class_name or task_module or write_task_module" -v`
+Expected: FAIL (`AttributeError` — helpers not defined)
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the module top of `scripts/monai_specs.py`, add constants and a re-export used by tests:
+
+```python
+import re
+
+BAKED_BUNDLE_ROOT = "/opt/bundles"
+PACKAGE = "australianimagingservice"
+```
+
+Add the methods to `MonaiModels`:
+
+```python
+    def class_name(self, entry: WhitelistEntry) -> str:
+        """CamelCase Python class name derived from the model name."""
+        words = re.split(r"[^a-zA-Z0-9]+", entry.name)
+        return "".join(w.capitalize() for w in words if w)
+
+    def _module_parts(self, entry: WhitelistEntry) -> List[str]:
+        return [PACKAGE, entry.modality, entry.species, entry.region, "monai", entry.name]
+
+    def task_module_path(self, entry: WhitelistEntry) -> Path:
+        parts = self._module_parts(entry)
+        return self.root.joinpath("src", *parts).with_suffix(".py")
+
+    def task_module_ref(self, entry: WhitelistEntry) -> str:
+        dotted = ".".join(self._module_parts(entry))
+        return f"{dotted}:{self.class_name(entry)}"
+
+    def write_task_module(self, entry: WhitelistEntry) -> Path:
+        """Generate a committed per-model task module (define()-built class).
+
+        The class bakes in the in-image bundle path so command.task can
+        reference it directly with no runtime configuration.
+        """
+        path = self.task_module_path(entry)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Ensure every generated package directory is importable.
+        pkg_dir = path.parent
+        src_root = self.root / "src"
+        while pkg_dir != src_root and src_root in pkg_dir.parents or pkg_dir == src_root:
+            init = pkg_dir / "__init__.py"
+            if not init.exists():
+                init.write_text("")
+            if pkg_dir == src_root:
+                break
+            pkg_dir = pkg_dir.parent
+
+        bundle_path = f"{BAKED_BUNDLE_ROOT}/{entry.name}"
+        cls = self.class_name(entry)
+        path.write_text(
+            '"""Auto-generated MONAI task module. Do not edit by hand."""\n'
+            "from pydra.compose import monai\n\n"
+            f'BUNDLE_PATH = "{bundle_path}"\n\n'
+            f'{cls} = monai.define(BUNDLE_PATH, name="{cls}")\n'
+        )
+        return path
+```
+
+Note on the `__init__.py` loop: it walks from the model's package dir up to `src/` inclusive, writing an empty `__init__.py` in each level that lacks one, so the full dotted path is importable inside the image.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "class_name or task_module or write_task_module" -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/monai_specs.py tests/test_monai_specs.py
+git commit -m "feat(monai): generate committed per-model task module for command.task
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Generate the full spec (fragment + overlay merge)
 
 **Files:**
 - Modify: `scripts/monai_specs.py`
@@ -421,12 +566,12 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Test: `tests/test_monai_specs.py`
 
 **Interfaces:**
-- Consumes: `pydra_compose_monai.spec_fragment(bundle_dir) -> {"sources","sinks","parameters"}` (Plan A, Task 1); a per-model overlay YAML.
+- Consumes: `pydra_compose_monai.spec_fragment(bundle_dir) -> {"sources","sinks","parameters"}` (Plan A); the per-model overlay YAML; `task_module_ref` (Task 4).
 - Produces:
   ```python
   def overlay_path(self, entry: WhitelistEntry) -> Path:      # scripts/overlays/<name>.yaml
   def generate_spec(self, entry: WhitelistEntry, bundle_dir: Path) -> dict:
-      # full XnatApp 2.x spec dict
+      # full XnatApp 2.x spec dict; command.task = task_module_ref(entry)
   ```
 - The merge rewrites each sink's `path` from the bundle metadata path (`network_data_format/outputs/<x>`) to the frametree store path `monai/<name>/<x>`.
 
@@ -500,8 +645,12 @@ def test_generate_spec_shape(tmp_path, whitelist_file, overlay_dir, monkeypatch)
     assert spec["version"] == "0.5.3"
     assert isinstance(spec["commands"], list) and len(spec["commands"]) == 1
     cmd = spec["commands"][0]
-    assert cmd["task"] == "pydra.compose.monai:BundleTask"
-    assert cmd["configuration"]["bundle"] == "/opt/bundles/spleen_ct_segmentation"
+    assert cmd["task"] == (
+        "australianimagingservice.ct.human.abdomen.monai."
+        "spleen_ct_segmentation:SpleenCtSegmentation"
+    )
+    # bundle is baked into the generated class, so configuration is empty
+    assert cmd["configuration"] == {}
     assert cmd["operates_on"] == "session"
     assert cmd["sources"]["image"]["datatype"] == "medimage/nifti-gz-x"
     # sink path rewritten to the frametree store path
@@ -521,8 +670,6 @@ At module top of `scripts/monai_specs.py` add:
 from pydra.compose.monai import spec_fragment
 
 OVERLAYS_DIR = Path(__file__).parent / "overlays"
-BAKED_BUNDLE_ROOT = "/opt/bundles"
-TASK_REF = "pydra.compose.monai:BundleTask"
 ```
 
 Add a module-level deep-merge helper and the methods:
@@ -548,6 +695,9 @@ def _deep_merge(base: dict, override: dict) -> dict:
 
         Combines the bundle-derived field fragment with the hand-authored
         overlay (title/authors/docs/base_image/packages/operates_on).
+        command.task references the committed generated per-model class
+        (see write_task_module); the bundle is baked into that class, so
+        the command needs no configuration.
         """
         overlay = yaml.safe_load(self.overlay_path(entry).read_text()) or {}
         fragment = spec_fragment(bundle_dir)
@@ -561,9 +711,9 @@ def _deep_merge(base: dict, override: dict) -> dict:
 
         operates_on = overlay.get("operates_on", "session")
         command = {
-            "task": TASK_REF,
+            "task": self.task_module_ref(entry),
             "operates_on": operates_on,
-            "configuration": {"bundle": f"{BAKED_BUNDLE_ROOT}/{entry.name}"},
+            "configuration": {},
             "sources": fragment["sources"],
             "sinks": sinks,
             "parameters": fragment["parameters"],
@@ -597,19 +747,20 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 5: Write spec to disk + `sync()` orchestration + CLI entry point
+### Task 6: Write spec to disk + `sync()` orchestration + CLI entry point
 
 **Files:**
 - Modify: `scripts/monai_specs.py`
 - Test: `tests/test_monai_specs.py`
 
 **Interfaces:**
-- Consumes: all prior methods; `monai.bundle.download` to fetch a bundle for generation.
+- Consumes: all prior methods, including `write_task_module` (Task 4); `monai.bundle.download` to fetch a bundle for generation.
 - Produces:
   ```python
   def write_spec(self, entry: WhitelistEntry, spec: dict) -> Path:   # writes YAML, returns path
   def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
-      # fetch -> filter -> detect_changes -> for each: download, generate, write
+      # fetch -> filter -> detect_changes -> for each: download, write_task_module, generate, write_spec
+      # returns the spec paths written
   # module: def main(argv=None) -> int   (argparse: subcommand "sync")
   ```
 
@@ -641,6 +792,9 @@ def test_sync_writes_only_changed(tmp_path, whitelist_file, overlay_dir, monkeyp
     written = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
     assert len(written) == 1
     assert written[0].is_file()
+    # sync also emitted the committed per-model task module
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    assert mm.task_module_path(entry).is_file()
 
     # Second run: version unchanged -> nothing written
     written2 = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
@@ -664,7 +818,11 @@ Add `from typing import Callable` to the typing imports, then add to `MonaiModel
         return path
 
     def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
-        """Full pipeline: fetch → filter → detect → generate → write.
+        """Full pipeline: fetch → filter → detect → codegen + generate → write.
+
+        For each changed model: download the bundle, write the committed
+        per-model task module, generate the spec (which references that
+        module), and write the spec. Returns the spec paths written.
 
         ``download_bundle`` maps an entry to a local bundle root directory
         (injected so tests need no network; production passes ``self._download``).
@@ -675,6 +833,7 @@ Add `from typing import Callable` to the typing imports, then add to `MonaiModel
         written: List[Path] = []
         for entry in changed:
             bundle_dir = download_bundle(entry)
+            self.write_task_module(entry)
             spec = self.generate_spec(entry, bundle_dir)
             written.append(self.write_spec(entry, spec))
         return written
@@ -736,15 +895,15 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 6: Contract check — generated spec loads as an XnatApp
+### Task 7: Contract check — generated spec loads as an XnatApp
 
 **Files:**
 - Test: `tests/test_monai_specs.py`
 
 **Interfaces:**
-- Consumes: `pydra2app.xnat.XnatApp.load` (already a test dep); a generated spec file.
+- Consumes: `pydra2app.xnat.XnatApp.load` (already a test dep); a generated spec file; the generated per-model task module (must be importable).
 
-This is the go/no-go for Option B (generic `BundleTask`) vs Option A (per-model generated class). If `XnatApp.load` rejects the spec because `command.sources`/`sinks` name fields that are not static attrs fields on `BundleTask`, escalate to Option A (see design doc "Open items").
+This is the go/no-go contract check for Option A. `XnatApp.load` resolves `command.task` by importing the dotted module reference and checking it subclasses `pydra.compose.base.Task`, then introspects its fields via `pydra.utils.get_fields`. For this test to import the generated module, it must be on `sys.path` — the test writes the module under `tmp_path/src/...` and the `sync`/`write_task_module` path uses the package name `australianimagingservice`, which is already importable from the repo's own `src/` (installed `-e`). Since the *generated* class name/path here point into a temp tree, this test instead asserts the spec's structure loads; a heavier end-to-end that actually imports a generated class is exercised by the existing `tests/test_monai.py` build path once a real model is committed. If `XnatApp.load` rejects the spec, record the error and escalate before proceeding.
 
 - [ ] **Step 1: Write the test**
 
@@ -784,20 +943,22 @@ Expected: PASS. If it FAILS on field resolution, record the error and escalate t
 
 ```bash
 git add tests/test_monai_specs.py
-git commit -m "test(monai): assert generated spec loads as an XnatApp (Option B go/no-go)
+git commit -m "test(monai): assert generated spec loads as an XnatApp (Option A contract check)
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
 
 ---
 
-### Task 7: Add dependency + scheduled GitHub Action
+### Task 8: Add dependency + scheduled GitHub Action
 
 **Files:**
 - Modify: `pyproject.toml:41` (add `pydra-compose-monai` to `test` deps)
 - Create: `.github/workflows/monai-sync.yml`
 
 **Interfaces:** none (CI wiring).
+
+> **Dependency availability:** `pydra-compose-monai` with `spec_fragment()` is on branch `docs/monai-spec-fragment-plan` (PR #12) and may not yet be on PyPI when this task runs. If the pinned PyPI release lacks `spec_fragment`, install from git in the meantime (e.g. `pydra-compose-monai @ git+https://github.com/Australian-Imaging-Service/pydra-compose-monai@docs/monai-spec-fragment-plan`) and switch to a version pin once released.
 
 - [ ] **Step 1: Add the dependency**
 
@@ -842,9 +1003,10 @@ jobs:
           base: monai-test
           title: "Update MONAI model specs"
           commit-message: "chore(monai): sync model specs from Model Zoo"
-          body: "Automated MONAI Model Zoo spec sync. Review generated specs before merge."
+          body: "Automated MONAI Model Zoo spec sync. Review generated specs and task modules before merge."
           add-paths: |
             specs/**/monai/**
+            src/australianimagingservice/**/monai/**
 ```
 
 - [ ] **Step 3: Validate the workflow YAML**
@@ -863,7 +1025,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 8: Full regression + lint
+### Task 9: Full regression + lint
 
 **Files:** none (verification only)
 
@@ -877,9 +1039,16 @@ Expected: all tests pass.
 Run: `.venv/bin/pytest tests/test_monai.py -v` (this is the network/XNAT test; expect it to be skipped/collected as before — it must not be newly broken by our changes).
 Expected: same collection/skip behavior as before this work; no new import errors from `scripts/`.
 
+- [ ] **Step 3: Sanity-check a generated task module imports (if pydra-compose-monai available)**
+
+Run: `.venv/bin/python -c "import scripts.monai_specs"` then, if `pydra.compose.monai` is installed, generate one module to a temp dir and byte-compile it:
+`.venv/bin/python -c "import ast, pathlib; ast.parse(pathlib.Path('scripts/monai_specs.py').read_text())"`
+Expected: no syntax errors. (Full import of a *generated* module requires `pydra-compose-monai` + a real bundle; that is covered by the build path in `tests/test_monai.py`.)
+
 ## Self-Review
 
-- **Spec coverage:** Component 2 (`MonaiModels` methods `fetch`/`filter`/`detect`/`generate`/`write`/`sync`) → Tasks 1–5. Whitelist + overlay control surfaces → Tasks 1 & 4. `monai/` namespace output → Task 1 `spec_path` + Task 5 `write_spec`. Option B go/no-go (`XnatApp.load`) → Task 6. Component 3 (scheduled PR-opening Action) → Task 7. Regression → Task 8. Depends-on Plan A's `spec_fragment`/`BundleTask` → Global Constraints + Task 7 dep. Complete.
+- **Spec coverage:** Component 2 (`MonaiModels` methods `fetch`/`filter`/`detect`/`generate`/`write`/`sync`) → Tasks 1–3, 5, 6. Per-model task-module codegen (Option A) → Task 4. Whitelist + overlay control surfaces → Tasks 1 & 5. `monai/` namespace output → Task 1 `spec_path` + Task 6 `write_spec`. Option A contract check (`XnatApp.load`) → Task 7. Component 3 (scheduled PR-opening Action, incl. generated `src/` paths) → Task 8. Regression → Task 9. Depends-on Plan A's `spec_fragment` → Global Constraints + Task 8 dep. Complete.
 - **Placeholder scan:** No TBD/TODO; every code step shows full code and exact commands. The overlay email uses a generic placeholder address (no PII).
-- **Type consistency:** `WhitelistEntry` fields (`name/version/modality/species/region`) used consistently; `spec_fragment` return shape (`sources`/`sinks`/`parameters`) matches Plan A and every consumer here; `TASK_REF`/`configuration.bundle` strings match between impl and tests; `sync(download_bundle=...)` signature consistent between Task 5 impl, tests, and CLI (`mm._download`).
-- **py38 constraint:** `scripts/` uses `Optional`/`List`/`Dict`/`Callable` from `typing`, no `X | Y` unions — consistent with repo target.
+- **Type consistency:** `WhitelistEntry` fields (`name/version/modality/species/region`) used consistently; `spec_fragment` return shape (`sources`/`sinks`/`parameters`) matches Plan A and every consumer here; `command.task` value equals `task_module_ref(entry)` in both the Task 5 impl and its test; `configuration` is `{}` consistently (bundle baked into the generated class); `sync(download_bundle=...)` signature consistent between Task 6 impl, tests, and CLI (`mm._download`).
+- **Option A consistency:** No remaining references to `BundleTask` or `configuration.bundle`; `command.task` is the generated dotted ref everywhere; `write_task_module` is called in `sync` (Task 6) and its output PR-tracked (Task 8).
+- **py38 constraint:** `scripts/` uses `Optional`/`List`/`Dict`/`Callable` from `typing`, no `X | Y` unions — consistent with repo target. Generated modules import from `pydra.compose.monai` (3.11+) but only ever run inside the built image.

--- a/docs/superpowers/plans/2026-07-10-monai-model-registry.md
+++ b/docs/superpowers/plans/2026-07-10-monai-model-registry.md
@@ -15,7 +15,7 @@
 - Depends on **`pydra-compose-monai`** providing `spec_fragment()` (Plan `2026-07-10-monai-spec-fragment.md` in the pydra-compose-monai repo, PR #12). That must ship / be installable first; add `pydra-compose-monai` to the `test` deps of `pyproject.toml`. NOTE: `BundleTask` was dropped from that plan — do not reference it.
 - `requires-python >=3.8` (repo target) — this repo targets py38, so **use `Optional[...]`/`Dict[...]` typing imports, NOT `X | Y` syntax**, in `scripts/`. (The *generated* task modules import from `pydra.compose.monai`, which requires 3.11 — that is fine because they only ever run inside the built image, not under the repo's py38 floor.)
 - Generated specs target the **pydra2app/pipeline2app 2.x schema** consumed by `XnatApp.load(...)` (see `tests/test_monai.py`): top-level `commands:` is a **list**; per-command keys `task`, `operates_on`, `sources`, `sinks`, `parameters`, `configuration`.
-- `command.task` = the dotted ref of the generated per-model class: `"australianimagingservice.<modality>.<species>.<region>.monai.<model>:<ClassName>"`. The class is a `define()`-built `MonaiTask` subclass whose `bundle` defaults to the baked-in path `/opt/bundles/<model>`. No `configuration.bundle` is needed (the default is baked into the class), so `configuration` is `{}`.
+- `command.task` = the dotted ref of the generated per-model class: `"australianimagingservice.<modality>.<species>.<region>.monai.<model>:<ClassName>"`. The class is a `define()`-built `MonaiTask` subclass that builds itself from the bundle **vendored beside the module** (`Path(__file__).parent / "<model>_bundle"`). No `configuration.bundle` is needed, so `configuration` is `{}`. (See the "Vendored bundle" revision note under Task 4: pipeline2app imports and introspects the task eagerly at spec-load / Dockerfile-generation time, so the bundle must be present on the build host, not only in the final image.)
 - Datatypes are fileformats MIME-like strings.
 - Generator lives in top-level `scripts/` (already excluded from mypy/package in `pyproject.toml`). Tests live in `tests/`. Generated task modules live in the installable package under `src/australianimagingservice/<modality>/<species>/<region>/monai/`.
 - Generated specs written under `specs/australian-imaging-service/<modality>/<species>/<region>/monai/<model>.yaml`.
@@ -432,7 +432,9 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
   def write_task_module(self, entry: WhitelistEntry) -> Path:
       # writes the generated .py (define()-built class, baked-in bundle path), returns path
   ```
-- The generated module baked-bundle path is `/opt/bundles/<model>` (`BAKED_BUNDLE_ROOT`).
+- The generated module references the **vendored bundle beside it**: `Path(__file__).parent / "<model>_bundle"`. See the "Vendored bundle" note below — the bundle is committed next to the module so `define()` resolves in CI, `--generate-only`, and in-image alike.
+
+> **Vendored bundle (revision 2026-07-24 — Task 7 finding):** pipeline2app resolves `command.task` EAGERLY at `App.load`, and Dockerfile generation calls `get_fields(task)` — so the task must be importable *and introspectable on the build host*, not only inside the final image. Our generated class calls `monai.define(<bundle>)` at import, which reads the bundle metadata. Therefore the bundle must be present wherever the spec is loaded/built. Decision: **vendor the bundle into the repo beside the generated module** at `<module_dir>/<model>_bundle/`, and have the generated module do `define(Path(__file__).parent / "<model>_bundle")` (a module-relative path, valid identically in CI and in-image). The sync step downloads and copies the bundle there (Task 6). For the PoC, bundles are committed as plain git blobs; see Open items re: git-lfs for large weights.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -458,15 +460,26 @@ def test_task_module_ref_and_path(tmp_path, whitelist_file):
     )
 
 
-def test_write_task_module_emits_importable_define_call(tmp_path, whitelist_file):
+def test_bundle_vendor_dir_beside_module(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.bundle_vendor_dir(entry) == (
+        mm.task_module_path(entry).parent / "spleen_ct_segmentation_bundle"
+    )
+
+
+def test_write_task_module_uses_module_relative_bundle(tmp_path, whitelist_file):
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
     entry = mm.whitelist()[0]
     path = mm.write_task_module(entry)
     assert path == mm.task_module_path(entry)
     text = path.read_text()
-    # references pydra-compose-monai define, bakes the bundle path, names the class
+    # references pydra-compose-monai define, uses a module-relative bundle path
+    # (NOT an absolute /opt/bundles path), and names the class
     assert "from pydra.compose import monai" in text
-    assert '"/opt/bundles/spleen_ct_segmentation"' in text
+    assert "Path(__file__).parent" in text
+    assert '"spleen_ct_segmentation_bundle"' in text
+    assert "/opt/bundles" not in text
     assert "SpleenCtSegmentation = monai.define(" in text
     # every generated package dir has an __init__.py so the dotted ref imports
     assert (path.parent / "__init__.py").is_file()
@@ -479,12 +492,11 @@ Expected: FAIL (`AttributeError` — helpers not defined)
 
 - [ ] **Step 3: Write minimal implementation**
 
-At the module top of `scripts/monai_specs.py`, add constants and a re-export used by tests:
+At the module top of `scripts/monai_specs.py`, add:
 
 ```python
 import re
 
-BAKED_BUNDLE_ROOT = "/opt/bundles"
 PACKAGE = "australianimagingservice"
 ```
 
@@ -507,38 +519,52 @@ Add the methods to `MonaiModels`:
         dotted = ".".join(self._module_parts(entry))
         return f"{dotted}:{self.class_name(entry)}"
 
+    def bundle_vendor_dir(self, entry: WhitelistEntry) -> Path:
+        """Directory where the model's bundle is vendored, beside its module."""
+        return self.task_module_path(entry).parent / f"{entry.name}_bundle"
+
     def write_task_module(self, entry: WhitelistEntry) -> Path:
         """Generate a committed per-model task module (define()-built class).
 
-        The class bakes in the in-image bundle path so command.task can
-        reference it directly with no runtime configuration.
+        The class builds itself from the bundle vendored beside this module
+        (``<model>_bundle/``), using a module-relative path so it resolves
+        identically on the build host (CI / --generate-only) and inside the
+        built image. pipeline2app imports and introspects this class eagerly
+        at spec-load / Dockerfile-generation time, so the bundle must be
+        present next to the module — which is why sync() vendors it (Task 6).
         """
         path = self.task_module_path(entry)
         path.parent.mkdir(parents=True, exist_ok=True)
 
         # Ensure every generated package directory is importable.
-        pkg_dir = path.parent
         src_root = self.root / "src"
-        while pkg_dir != src_root and src_root in pkg_dir.parents or pkg_dir == src_root:
-            init = pkg_dir / "__init__.py"
-            if not init.exists():
-                init.write_text("")
+        pkg_dirs = []
+        pkg_dir = path.parent
+        while True:
+            pkg_dirs.append(pkg_dir)
             if pkg_dir == src_root:
                 break
             pkg_dir = pkg_dir.parent
+        for d in pkg_dirs:
+            init = d / "__init__.py"
+            if not init.exists():
+                init.write_text("")
 
-        bundle_path = f"{BAKED_BUNDLE_ROOT}/{entry.name}"
         cls = self.class_name(entry)
+        bundle_dirname = f"{entry.name}_bundle"
         path.write_text(
             '"""Auto-generated MONAI task module. Do not edit by hand."""\n'
+            "from pathlib import Path\n"
             "from pydra.compose import monai\n\n"
-            f'BUNDLE_PATH = "{bundle_path}"\n\n'
+            f'BUNDLE_PATH = Path(__file__).parent / "{bundle_dirname}"\n\n'
             f'{cls} = monai.define(BUNDLE_PATH, name="{cls}")\n'
         )
         return path
 ```
 
-Note on the `__init__.py` loop: it walks from the model's package dir up to `src/` inclusive, writing an empty `__init__.py` in each level that lacks one, so the full dotted path is importable inside the image.
+Notes:
+- The `__init__.py` loop collects every package directory from the model's dir up to `src/` inclusive, then writes an empty `__init__.py` in each that lacks one — so the full dotted path imports. (This is the clearer list-collection form the Task-4 implementer already used; keep it.)
+- The generated module uses `Path(__file__).parent / "<model>_bundle"` — a module-relative path — so `monai.define()` reads the vendored bundle regardless of CWD or absolute mount points.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -785,17 +811,25 @@ def test_sync_writes_only_changed(tmp_path, whitelist_file, overlay_dir, monkeyp
         ms, "spec_fragment",
         lambda bundle: {"sources": {}, "sinks": {}, "parameters": {}},
     )
+
+    # A fake downloaded bundle dir for vendor_bundle to copy.
+    fake_bundle = tmp_path / "downloaded_bundle"
+    (fake_bundle / "configs").mkdir(parents=True)
+    (fake_bundle / "configs" / "metadata.json").write_text("{}")
+
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
 
-    written = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    written = mm.sync(download_bundle=lambda entry: fake_bundle)
     assert len(written) == 1
     assert written[0].is_file()
-    # sync also emitted the committed per-model task module
+    # sync also emitted the committed per-model task module ...
     entry = mm.whitelist()[0]._replace(version="0.5.3")
     assert mm.task_module_path(entry).is_file()
+    # ... and vendored the bundle beside it
+    assert (mm.bundle_vendor_dir(entry) / "configs" / "metadata.json").is_file()
 
     # Second run: version unchanged -> nothing written
-    written2 = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    written2 = mm.sync(download_bundle=lambda entry: fake_bundle)
     assert written2 == []
 ```
 
@@ -815,12 +849,29 @@ Add `from typing import Callable` to the typing imports, then add to `MonaiModel
         path.write_text(yaml.safe_dump(spec, sort_keys=False))
         return path
 
-    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
-        """Full pipeline: fetch → filter → detect → codegen + generate → write.
+    def vendor_bundle(self, entry: WhitelistEntry, bundle_dir: Path) -> Path:
+        """Copy the downloaded bundle to sit beside the generated module.
 
-        For each changed model: download the bundle, write the committed
-        per-model task module, generate the spec (which references that
-        module), and write the spec. Returns the spec paths written.
+        The generated task module reads the bundle via a module-relative path
+        (``Path(__file__).parent / "<model>_bundle"``), so the bundle must be
+        committed there. Idempotent: replaces any existing vendored copy.
+        """
+        import shutil
+
+        dest = self.bundle_vendor_dir(entry)
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(bundle_dir, dest)
+        return dest
+
+    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
+        """Full pipeline: fetch → filter → detect → vendor + codegen + generate → write.
+
+        For each changed model: download the bundle, vendor it beside the
+        generated module, write the committed per-model task module, generate
+        the spec (which references that module + vendored bundle), and write
+        the spec. Returns the spec paths written.
 
         ``download_bundle`` maps an entry to a local bundle root directory
         (injected so tests need no network; production passes ``self._download``).
@@ -832,6 +883,7 @@ Add `from typing import Callable` to the typing imports, then add to `MonaiModel
         for entry in changed:
             bundle_dir = download_bundle(entry)
             self.write_task_module(entry)
+            self.vendor_bundle(entry, bundle_dir)
             spec = self.generate_spec(entry, bundle_dir)
             written.append(self.write_spec(entry, spec))
         return written
@@ -899,16 +951,39 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Test: `tests/test_monai_specs.py`
 
 **Interfaces:**
-- Consumes: `pydra2app.xnat.XnatApp.load` (already a test dep); a generated spec file; the generated per-model task module (must be importable).
+- Consumes: `pydra2app.xnat.XnatApp.load`; a full `sync()` run against a synthetic bundle; the generated per-model task module + vendored bundle.
 
-This is the go/no-go contract check for Option A. `XnatApp.load` resolves `command.task` by importing the dotted module reference and checking it subclasses `pydra.compose.base.Task`, then introspects its fields via `pydra.utils.get_fields`. For this test to import the generated module, it must be on `sys.path` — the test writes the module under `tmp_path/src/...` and the `sync`/`write_task_module` path uses the package name `australianimagingservice`, which is already importable from the repo's own `src/` (installed `-e`). Since the *generated* class name/path here point into a temp tree, this test instead asserts the spec's structure loads; a heavier end-to-end that actually imports a generated class is exercised by the existing `tests/test_monai.py` build path once a real model is committed. If `XnatApp.load` rejects the spec, record the error and escalate before proceeding.
+This is the **go/no-go contract check for Option A**, and it is a genuine end-to-end test (verified working during planning). `XnatApp.load` resolves `command.task` EAGERLY by importing the dotted module reference and introspecting its fields via `pydra.utils.get_fields`. Our generated module calls `monai.define(<vendored bundle>)` at import, so for the load to succeed: (1) a real bundle must be vendored beside the module (done by `sync`→`vendor_bundle`), and (2) `<root>/src` must be on `sys.path` so the dotted `australianimagingservice…` ref imports. The test arranges both, then asserts the load resolves `command.task` to the generated class. If `XnatApp.load` raises, record the verbatim error and escalate — do NOT weaken the assertion to force a pass.
 
 - [ ] **Step 1: Write the test**
 
-Append to `tests/test_monai_specs.py`:
+Append to `tests/test_monai_specs.py`. Note the `_synthetic_bundle` helper builds a real MONAI bundle (`configs/metadata.json` + `configs/inference.json`) so `monai.define()` succeeds at import; `sys.path` is extended (and restored) so the generated module imports:
 
 ```python
+import json
+import sys
+
+
+def _make_synthetic_bundle(dest: Path) -> Path:
+    configs = dest / "configs"
+    configs.mkdir(parents=True, exist_ok=True)
+    (configs / "metadata.json").write_text(json.dumps({
+        "name": "SpleenCtSegmentation",
+        "network_data_format": {
+            "inputs": {"image": {"type": "image", "modality": "CT"}},
+            "outputs": {"pred": {"type": "image", "format": "segmentation"}},
+        },
+    }))
+    (configs / "inference.json").write_text(json.dumps({
+        "postprocessing": {"_target_": "Compose", "transforms": [
+            {"_target_": "SaveImaged", "keys": ["pred"], "output_postfix": "seg"}
+        ]}
+    }))
+    return dest
+
+
 def test_generated_spec_loads_as_xnatapp(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import importlib
     import scripts.monai_specs as ms
     from pydra2app.xnat import XnatApp
 
@@ -922,20 +997,29 @@ def test_generated_spec_loads_as_xnatapp(tmp_path, whitelist_file, overlay_dir, 
             "parameters": {},
         },
     )
+    bundle = _make_synthetic_bundle(tmp_path / "downloaded")
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
-    entry = mm.whitelist()[0]._replace(version="0.5.3")
-    spec = mm.generate_spec(entry, bundle_dir=tmp_path / "bundle")
-    path = mm.write_spec(entry, spec)
 
-    image_spec = XnatApp.load(path)
+    # Full sync path: writes the module, vendors the bundle beside it, writes the spec.
+    written = mm.sync(download_bundle=lambda entry: bundle)
+    assert len(written) == 1
+    spec_path = written[0]
+
+    # Make the generated module importable, then load the spec (eager task import).
+    monkeypatch.syspath_prepend(str(tmp_path / "src"))
+    importlib.invalidate_caches()
+
+    image_spec = XnatApp.load(spec_path)
     assert image_spec.commands
     assert image_spec.commands[0].name
+    # command.task resolved to an actual class (not left as an unresolved string)
+    assert not isinstance(image_spec.commands[0].task, str)
 ```
 
 - [ ] **Step 2: Run the test**
 
 Run: `.venv/bin/pytest tests/test_monai_specs.py -k xnatapp -v`
-Expected: PASS. If it FAILS on field resolution, record the error and escalate to Option A per the design doc before proceeding.
+Expected: PASS (verified during planning: `XnatApp.load` resolves `command.task` to the generated `SpleenCtSegmentation` class and `commands` introspects). If it FAILS, record the verbatim error and escalate before proceeding — do not weaken the assertion.
 
 - [ ] **Step 3: Commit**
 
@@ -1049,4 +1133,10 @@ Expected: no syntax errors. (Full import of a *generated* module requires `pydra
 - **Placeholder scan:** No TBD/TODO; every code step shows full code and exact commands. The overlay email uses a generic placeholder address (no PII).
 - **Type consistency:** `WhitelistEntry` fields (`name/version/modality/species/region`) used consistently; `spec_fragment` return shape (`sources`/`sinks`/`parameters`) matches Plan A and every consumer here; `command.task` value equals `task_module_ref(entry)` in both the Task 5 impl and its test; `configuration` is `{}` consistently (bundle baked into the generated class); `sync(download_bundle=...)` signature consistent between Task 6 impl, tests, and CLI (`mm._download`).
 - **Option A consistency:** No remaining references to `BundleTask` or `configuration.bundle`; `command.task` is the generated dotted ref everywhere; `write_task_module` is called in `sync` (Task 6) and its output PR-tracked (Task 8).
-- **py38 constraint:** `scripts/` uses `Optional`/`List`/`Dict`/`Callable` from `typing`, no `X | Y` unions — consistent with repo target. Generated modules import from `pydra.compose.monai` (3.11+) but only ever run inside the built image.
+- **Vendored-bundle consistency (2026-07-24 revision):** the generated module reads its bundle module-relative (`Path(__file__).parent / "<model>_bundle"`), NOT `/opt/bundles`; `sync` calls `vendor_bundle` (Task 6) to place it there; the Task 8 `add-paths` `src/australianimagingservice/**/monai/**` covers the vendored `<model>_bundle/` dirs; the Task 7 contract check was verified to load end-to-end with the bundle vendored + `src` on `sys.path`.
+- **py38 constraint:** `scripts/` uses `Optional`/`List`/`Dict`/`Callable` from `typing`, no `X | Y` unions — consistent with repo target. Generated modules import from `pydra.compose.monai` (3.11+) but only ever run where a bundle is vendored beside them (build host + image), not under the repo's py38 tooling floor.
+
+## Open items
+
+- **git-lfs for bundle weights.** For the PoC, vendored bundles are committed as plain git blobs (the PoC model is small). Before adding models with large weights (`.pt`/`.ts`, often tens–hundreds of MB), move `src/australianimagingservice/**/monai/**_bundle/**` weight files to git-lfs (and ensure CI/build hosts have `git lfs` installed). Track this when the whitelist grows beyond the PoC model.
+- **Auto-generate overlay metadata** (replace hand-authored overlays with a MONAI runtime template + repo defaults) — deferred from the design.

--- a/docs/superpowers/plans/2026-07-10-monai-model-registry.md
+++ b/docs/superpowers/plans/2026-07-10-monai-model-registry.md
@@ -291,13 +291,11 @@ Add methods to `MonaiModels`:
     def fetch_available(self) -> Dict[str, str]:
         """Return ``{bundle_name: latest_version}`` from the MONAI Model Zoo.
 
-        ``get_all_bundles_list`` returns ``(name, version)`` pairs newest-first;
-        the first occurrence of each name is its latest version.
+        ``monai.bundle.get_all_bundles_list()`` returns one
+        ``(bundle_name, latest_version)`` tuple per bundle (already reduced to
+        the latest version per bundle), so we build the mapping directly.
         """
-        available: Dict[str, str] = {}
-        for name, version in get_all_bundles_list():
-            available.setdefault(name, version)
-        return available
+        return {name: version for name, version in get_all_bundles_list()}
 
     def filter_whitelist(self, available: Dict[str, str]) -> List[WhitelistEntry]:
         """Keep whitelist entries present in ``available``; fill unpinned versions."""

--- a/docs/superpowers/plans/2026-07-10-monai-model-registry.md
+++ b/docs/superpowers/plans/2026-07-10-monai-model-registry.md
@@ -1,0 +1,885 @@
+# MONAI Model Registry + Spec Generator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `MonaiModels` generator (in `scripts/`) that fetches MONAI Model Zoo bundles, filters by a whitelist, detects version changes, generates pipeline2app XNAT specs (using `pydra-compose-monai`), and writes them into a `monai/` spec namespace — driven by a scheduled GitHub Action that opens a PR.
+
+**Architecture:** A single orchestrator class `MonaiModels` with focused, independently-testable methods (fetch → filter → detect → generate → write → sync). MONAI→fileformats field serialization is delegated to `pydra_compose_monai.spec_fragment`; catalog/build metadata comes from a hand-authored per-model overlay deep-merged with the fragment. Generated specs are `pydra2app`/`pipeline2app` 2.x `XnatApp` specs.
+
+**Tech Stack:** Python ≥3.8, PyYAML, monai.bundle, pydra-compose-monai (from PyPI), pydra2app/pydra2app-xnat, pytest. Work lands on the existing `monai-test` branch.
+
+## Global Constraints
+
+- Depends on **`pydra-compose-monai`** providing `spec_fragment()` and `BundleTask` (Plan `2026-07-10-monai-spec-fragment.md` in the pydra-compose-monai repo). That must ship first; add `pydra-compose-monai` to the `test` deps of `pyproject.toml`.
+- `requires-python >=3.8` (repo target) — this repo targets py38, so **use `Optional[...]`/`Dict[...]` typing imports, NOT `X | Y` syntax**, in `scripts/`.
+- Generated specs target the **pydra2app/pipeline2app 2.x schema** consumed by `XnatApp.load(...)` (see `tests/test_monai.py`): top-level `commands:` is a **list**; per-command keys `task`, `operates_on`, `sources`, `sinks`, `parameters`, `configuration`.
+- `command.task` = `"pydra.compose.monai:BundleTask"`; bundle fixed via `configuration: {bundle: /opt/bundles/<model>}`.
+- Datatypes are fileformats MIME-like strings.
+- Generator lives in top-level `scripts/` (already excluded from mypy/package in `pyproject.toml`). Tests live in `tests/`.
+- Generated specs written under `specs/australian-imaging-service/<modality>/<species>/<region>/monai/<model>.yaml`.
+- The Action opens a **PR**, never pushes to a protected branch directly.
+
+## File Structure
+
+- `scripts/monai_specs.py` — `MonaiModels` class + a `__main__` entry point (`python -m scripts.monai_specs sync`).
+- `scripts/monai_whitelist.yaml` — control surface: models, optional version pins, anatomy placement.
+- `scripts/overlays/<model>.yaml` — per-model hand-authored catalog/build metadata.
+- `tests/test_monai_specs.py` — unit tests for each method against synthetic bundles.
+- `.github/workflows/monai-sync.yml` — scheduled sync Action.
+
+---
+
+### Task 1: Whitelist loader + model placement resolution
+
+**Files:**
+- Create: `scripts/monai_specs.py`
+- Create: `scripts/monai_whitelist.yaml`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Produces:
+  ```python
+  class WhitelistEntry(ty.NamedTuple):
+      name: str
+      version: Optional[str]          # pin, or None for latest
+      modality: str
+      species: str
+      region: str
+  class MonaiModels:
+      def __init__(self, root: Path, whitelist_path: Path): ...
+      def whitelist(self) -> List[WhitelistEntry]: ...
+      def spec_path(self, entry: WhitelistEntry) -> Path: ...  # <root>/specs/australian-imaging-service/<modality>/<species>/<region>/monai/<name>.yaml
+  ```
+
+- [ ] **Step 1: Write the whitelist fixture file**
+
+Create `scripts/monai_whitelist.yaml`:
+
+```yaml
+# MONAI Model Zoo models to publish as AIS pipelines.
+# Each entry: version pin (null = latest) and anatomy placement in specs/ tree.
+models:
+  spleen_ct_segmentation:
+    version: null
+    modality: ct
+    species: human
+    region: abdomen
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_monai_specs.py`:
+
+```python
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR.parent))
+
+from scripts.monai_specs import MonaiModels, WhitelistEntry  # noqa: E402
+
+
+@pytest.fixture
+def whitelist_file(tmp_path: Path) -> Path:
+    p = tmp_path / "monai_whitelist.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "spleen_ct_segmentation": {
+                        "version": None,
+                        "modality": "ct",
+                        "species": "human",
+                        "region": "abdomen",
+                    }
+                }
+            }
+        )
+    )
+    return p
+
+
+def test_whitelist_parses_entries(tmp_path: Path, whitelist_file: Path):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entries = mm.whitelist()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e == WhitelistEntry("spleen_ct_segmentation", None, "ct", "human", "abdomen")
+
+
+def test_spec_path_follows_monai_namespace(tmp_path: Path, whitelist_file: Path):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    expected = (
+        tmp_path
+        / "specs"
+        / "australian-imaging-service"
+        / "ct"
+        / "human"
+        / "abdomen"
+        / "monai"
+        / "spleen_ct_segmentation.yaml"
+    )
+    assert mm.spec_path(entry) == expected
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/gbro5457/code/pipelines && .venv/bin/pytest tests/test_monai_specs.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'scripts.monai_specs'`
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `scripts/monai_specs.py`:
+
+```python
+"""Generate pipeline2app XNAT specs from whitelisted MONAI Model Zoo bundles."""
+import typing as ty
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+
+class WhitelistEntry(ty.NamedTuple):
+    name: str
+    version: Optional[str]
+    modality: str
+    species: str
+    region: str
+
+
+class MonaiModels:
+    """Fetch, filter, generate and write MONAI-bundle pipeline specs."""
+
+    def __init__(self, root: Path, whitelist_path: Path) -> None:
+        self.root = Path(root)
+        self.whitelist_path = Path(whitelist_path)
+
+    def whitelist(self) -> List[WhitelistEntry]:
+        data = yaml.safe_load(self.whitelist_path.read_text()) or {}
+        models: Dict[str, dict] = data.get("models", {})
+        entries: List[WhitelistEntry] = []
+        for name, cfg in models.items():
+            entries.append(
+                WhitelistEntry(
+                    name=name,
+                    version=cfg.get("version"),
+                    modality=cfg["modality"],
+                    species=cfg["species"],
+                    region=cfg["region"],
+                )
+            )
+        return entries
+
+    def spec_path(self, entry: WhitelistEntry) -> Path:
+        return (
+            self.root
+            / "specs"
+            / "australian-imaging-service"
+            / entry.modality
+            / entry.species
+            / entry.region
+            / "monai"
+            / f"{entry.name}.yaml"
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/monai_specs.py scripts/monai_whitelist.yaml tests/test_monai_specs.py
+git commit -m "feat(monai): whitelist loader and spec-path resolution
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Fetch available models + versions from the Model Zoo
+
+**Files:**
+- Modify: `scripts/monai_specs.py`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: `monai.bundle.get_all_bundles_list()`, `monai.bundle.get_bundle_versions(name)`.
+- Produces:
+  ```python
+  def fetch_available(self) -> Dict[str, str]:  # {bundle_name: latest_version}
+  def filter_whitelist(self, available: Dict[str, str]) -> List[WhitelistEntry]:
+      # entries whose name is in `available`; version pin kept if set else latest
+  ```
+
+- [ ] **Step 1: Write the failing test** (monkeypatch the network calls)
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+def test_filter_whitelist_keeps_available_and_fills_latest(
+    tmp_path: Path, whitelist_file: Path
+):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    available = {"spleen_ct_segmentation": "0.5.3", "other_model": "1.0.0"}
+    kept = mm.filter_whitelist(available)
+    assert len(kept) == 1
+    assert kept[0].name == "spleen_ct_segmentation"
+    assert kept[0].version == "0.5.3"  # pin was None -> latest filled in
+
+
+def test_filter_whitelist_respects_pin(tmp_path: Path):
+    wl = tmp_path / "wl.yaml"
+    wl.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "spleen_ct_segmentation": {
+                        "version": "0.5.0",
+                        "modality": "ct",
+                        "species": "human",
+                        "region": "abdomen",
+                    }
+                }
+            }
+        )
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=wl)
+    kept = mm.filter_whitelist({"spleen_ct_segmentation": "0.5.3"})
+    assert kept[0].version == "0.5.0"
+
+
+def test_fetch_available_uses_monai_api(tmp_path, whitelist_file, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(
+        ms, "get_all_bundles_list",
+        lambda **kw: [("spleen_ct_segmentation", "0.5.3")],
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    available = mm.fetch_available()
+    assert available["spleen_ct_segmentation"] == "0.5.3"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "filter_whitelist or fetch_available" -v`
+Expected: FAIL (`AttributeError`/`ImportError` — names not defined)
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the top of `scripts/monai_specs.py`, add the import (module-level so tests can monkeypatch it):
+
+```python
+from monai.bundle import get_all_bundles_list
+```
+
+Add methods to `MonaiModels`:
+
+```python
+    def fetch_available(self) -> Dict[str, str]:
+        """Return ``{bundle_name: latest_version}`` from the MONAI Model Zoo.
+
+        ``get_all_bundles_list`` returns ``(name, version)`` pairs newest-first;
+        the first occurrence of each name is its latest version.
+        """
+        available: Dict[str, str] = {}
+        for name, version in get_all_bundles_list():
+            available.setdefault(name, version)
+        return available
+
+    def filter_whitelist(self, available: Dict[str, str]) -> List[WhitelistEntry]:
+        """Keep whitelist entries present in ``available``; fill unpinned versions."""
+        kept: List[WhitelistEntry] = []
+        for entry in self.whitelist():
+            if entry.name not in available:
+                continue
+            version = entry.version or available[entry.name]
+            kept.append(entry._replace(version=version))
+        return kept
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "filter_whitelist or fetch_available" -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/monai_specs.py tests/test_monai_specs.py
+git commit -m "feat(monai): fetch Model Zoo listing and filter by whitelist
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Detect version changes vs existing specs
+
+**Files:**
+- Modify: `scripts/monai_specs.py`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: `self.spec_path(entry)` (Task 1); existing spec YAML with a top-level `version:` string.
+- Produces:
+  ```python
+  def existing_version(self, entry: WhitelistEntry) -> Optional[str]:  # None if no spec
+  def detect_changes(self, entries: List[WhitelistEntry]) -> List[WhitelistEntry]:
+      # entries whose resolved version != existing spec version (new or updated)
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+def _write_spec(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({"name": path.stem, "version": version}))
+
+
+def test_existing_version_none_when_missing(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.existing_version(entry) is None
+
+
+def test_detect_changes_flags_new_and_updated(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+
+    # No spec yet -> flagged as changed (new)
+    assert mm.detect_changes([entry]) == [entry]
+
+    # Spec at same version -> not flagged
+    _write_spec(mm.spec_path(entry), "0.5.3")
+    assert mm.detect_changes([entry]) == []
+
+    # Spec at older version -> flagged (updated)
+    _write_spec(mm.spec_path(entry), "0.5.0")
+    assert mm.detect_changes([entry]) == [entry]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "existing_version or detect_changes" -v`
+Expected: FAIL (`AttributeError: 'MonaiModels' object has no attribute ...`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `MonaiModels`:
+
+```python
+    def existing_version(self, entry: WhitelistEntry) -> Optional[str]:
+        path = self.spec_path(entry)
+        if not path.is_file():
+            return None
+        data = yaml.safe_load(path.read_text()) or {}
+        version = data.get("version")
+        return str(version) if version is not None else None
+
+    def detect_changes(self, entries: List[WhitelistEntry]) -> List[WhitelistEntry]:
+        """Return entries with no spec yet, or whose version differs from the spec."""
+        changed: List[WhitelistEntry] = []
+        for entry in entries:
+            if self.existing_version(entry) != entry.version:
+                changed.append(entry)
+        return changed
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "existing_version or detect_changes" -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/monai_specs.py tests/test_monai_specs.py
+git commit -m "feat(monai): detect new/updated models vs existing specs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Generate a full spec (fragment + overlay merge)
+
+**Files:**
+- Modify: `scripts/monai_specs.py`
+- Create: `scripts/overlays/spleen_ct_segmentation.yaml`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: `pydra_compose_monai.spec_fragment(bundle_dir) -> {"sources","sinks","parameters"}` (Plan A, Task 1); a per-model overlay YAML.
+- Produces:
+  ```python
+  def overlay_path(self, entry: WhitelistEntry) -> Path:      # scripts/overlays/<name>.yaml
+  def generate_spec(self, entry: WhitelistEntry, bundle_dir: Path) -> dict:
+      # full XnatApp 2.x spec dict
+  ```
+- The merge rewrites each sink's `path` from the bundle metadata path (`network_data_format/outputs/<x>`) to the frametree store path `monai/<name>/<x>`.
+
+- [ ] **Step 1: Write the overlay fixture**
+
+Create `scripts/overlays/spleen_ct_segmentation.yaml`:
+
+```yaml
+title: MONAI Spleen CT Segmentation
+authors:
+  - name: MONAI Consortium
+    email: monai.contact@gmail.com
+docs:
+  info_url: https://monai.io/model-zoo.html
+base_image:
+  name: projectmonai/monai
+  tag: latest
+  package_manager: apt
+packages:
+  pip:
+    pydra-compose-monai:
+operates_on: session
+```
+
+- [ ] **Step 2: Write the failing test** (stub `spec_fragment` via monkeypatch — no real bundle needed)
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+@pytest.fixture
+def overlay_dir(tmp_path: Path, monkeypatch) -> Path:
+    import scripts.monai_specs as ms
+
+    d = tmp_path / "overlays"
+    d.mkdir()
+    (d / "spleen_ct_segmentation.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "title": "MONAI Spleen CT Segmentation",
+                "authors": [{"name": "MONAI Consortium", "email": "x@example.org"}],
+                "docs": {"info_url": "https://monai.io/model-zoo.html"},
+                "base_image": {"name": "projectmonai/monai", "tag": "latest",
+                               "package_manager": "apt"},
+                "packages": {"pip": {"pydra-compose-monai": None}},
+                "operates_on": "session",
+            }
+        )
+    )
+    monkeypatch.setattr(ms, "OVERLAYS_DIR", d)
+    return d
+
+
+def test_generate_spec_shape(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {
+            "sources": {"image": {"datatype": "medimage/nifti-gz-x",
+                                  "help": "in", "path": "network_data_format/inputs/image"}},
+            "sinks": {"pred": {"datatype": "medimage/nifti-gz-x",
+                               "help": "out", "path": "network_data_format/outputs/pred"}},
+            "parameters": {},
+        },
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    spec = mm.generate_spec(entry, bundle_dir=tmp_path / "bundle")
+
+    assert spec["title"] == "MONAI Spleen CT Segmentation"
+    assert spec["version"] == "0.5.3"
+    assert isinstance(spec["commands"], list) and len(spec["commands"]) == 1
+    cmd = spec["commands"][0]
+    assert cmd["task"] == "pydra.compose.monai:BundleTask"
+    assert cmd["configuration"]["bundle"] == "/opt/bundles/spleen_ct_segmentation"
+    assert cmd["operates_on"] == "session"
+    assert cmd["sources"]["image"]["datatype"] == "medimage/nifti-gz-x"
+    # sink path rewritten to the frametree store path
+    assert cmd["sinks"]["pred"]["path"] == "monai/spleen_ct_segmentation/pred"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k generate_spec -v`
+Expected: FAIL (`AttributeError`/`ImportError` — `spec_fragment`/`OVERLAYS_DIR`/`generate_spec` not defined)
+
+- [ ] **Step 4: Write minimal implementation**
+
+At module top of `scripts/monai_specs.py` add:
+
+```python
+from pydra.compose.monai import spec_fragment
+
+OVERLAYS_DIR = Path(__file__).parent / "overlays"
+BAKED_BUNDLE_ROOT = "/opt/bundles"
+TASK_REF = "pydra.compose.monai:BundleTask"
+```
+
+Add a module-level deep-merge helper and the methods:
+
+```python
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursive merge; ``override`` wins on scalar conflicts."""
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+```
+
+```python
+    def overlay_path(self, entry: WhitelistEntry) -> Path:
+        return OVERLAYS_DIR / f"{entry.name}.yaml"
+
+    def generate_spec(self, entry: WhitelistEntry, bundle_dir: Path) -> dict:
+        """Build a full pipeline2app XNAT spec dict for a model.
+
+        Combines the bundle-derived field fragment with the hand-authored
+        overlay (title/authors/docs/base_image/packages/operates_on).
+        """
+        overlay = yaml.safe_load(self.overlay_path(entry).read_text()) or {}
+        fragment = spec_fragment(bundle_dir)
+
+        # Rewrite sink paths from bundle metadata paths to frametree store paths.
+        sinks = {}
+        for out_name, sink in fragment["sinks"].items():
+            sink = dict(sink)
+            sink["path"] = f"monai/{entry.name}/{out_name}"
+            sinks[out_name] = sink
+
+        operates_on = overlay.get("operates_on", "session")
+        command = {
+            "task": TASK_REF,
+            "operates_on": operates_on,
+            "configuration": {"bundle": f"{BAKED_BUNDLE_ROOT}/{entry.name}"},
+            "sources": fragment["sources"],
+            "sinks": sinks,
+            "parameters": fragment["parameters"],
+        }
+
+        spec = {
+            "name": entry.name,
+            "version": entry.version,
+            "commands": [command],
+        }
+        # overlay supplies title/authors/docs/base_image/packages; it must not
+        # override name/version/commands, so merge overlay UNDER the core spec.
+        merged = _deep_merge(overlay, spec)
+        merged.pop("operates_on", None)  # consumed into the command
+        return merged
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k generate_spec -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/monai_specs.py scripts/overlays/spleen_ct_segmentation.yaml tests/test_monai_specs.py
+git commit -m "feat(monai): generate full XNAT spec from bundle fragment + overlay
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Write spec to disk + `sync()` orchestration + CLI entry point
+
+**Files:**
+- Modify: `scripts/monai_specs.py`
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: all prior methods; `monai.bundle.download` to fetch a bundle for generation.
+- Produces:
+  ```python
+  def write_spec(self, entry: WhitelistEntry, spec: dict) -> Path:   # writes YAML, returns path
+  def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
+      # fetch -> filter -> detect_changes -> for each: download, generate, write
+  # module: def main(argv=None) -> int   (argparse: subcommand "sync")
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+def test_write_spec_creates_yaml(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    path = mm.write_spec(entry, {"name": entry.name, "version": "0.5.3", "commands": []})
+    assert path == mm.spec_path(entry)
+    reloaded = yaml.safe_load(path.read_text())
+    assert reloaded["version"] == "0.5.3"
+
+
+def test_sync_writes_only_changed(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(ms, "get_all_bundles_list",
+                        lambda **kw: [("spleen_ct_segmentation", "0.5.3")])
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {"sources": {}, "sinks": {}, "parameters": {}},
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+
+    written = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    assert len(written) == 1
+    assert written[0].is_file()
+
+    # Second run: version unchanged -> nothing written
+    written2 = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    assert written2 == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "write_spec or sync" -v`
+Expected: FAIL (`AttributeError` — `write_spec`/`sync` not defined)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `from typing import Callable` to the typing imports, then add to `MonaiModels`:
+
+```python
+    def write_spec(self, entry: WhitelistEntry, spec: dict) -> Path:
+        path = self.spec_path(entry)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(spec, sort_keys=False))
+        return path
+
+    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
+        """Full pipeline: fetch → filter → detect → generate → write.
+
+        ``download_bundle`` maps an entry to a local bundle root directory
+        (injected so tests need no network; production passes ``self._download``).
+        """
+        available = self.fetch_available()
+        whitelisted = self.filter_whitelist(available)
+        changed = self.detect_changes(whitelisted)
+        written: List[Path] = []
+        for entry in changed:
+            bundle_dir = download_bundle(entry)
+            spec = self.generate_spec(entry, bundle_dir)
+            written.append(self.write_spec(entry, spec))
+        return written
+
+    def _download(self, entry: WhitelistEntry) -> Path:
+        """Download a bundle from the Model Zoo into ``<root>/.monai-bundles``."""
+        from monai.bundle import download
+
+        dest = self.root / ".monai-bundles"
+        dest.mkdir(parents=True, exist_ok=True)
+        download(name=entry.name, version=entry.version, bundle_dir=str(dest))
+        return dest / entry.name
+```
+
+At the end of `scripts/monai_specs.py` add the CLI entry point:
+
+```python
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sync MONAI Model Zoo specs")
+    parser.add_argument("command", choices=["sync"])
+    parser.add_argument("--root", type=Path, default=Path(__file__).parent.parent)
+    parser.add_argument(
+        "--whitelist", type=Path,
+        default=Path(__file__).parent / "monai_whitelist.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    mm = MonaiModels(root=args.root, whitelist_path=args.whitelist)
+    written = mm.sync(download_bundle=mm._download)
+    for path in written:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k "write_spec or sync" -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Run the full new test file**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -v`
+Expected: PASS (all tasks' tests green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/monai_specs.py tests/test_monai_specs.py
+git commit -m "feat(monai): write specs, sync orchestration and CLI entry point
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Contract check — generated spec loads as an XnatApp
+
+**Files:**
+- Test: `tests/test_monai_specs.py`
+
+**Interfaces:**
+- Consumes: `pydra2app.xnat.XnatApp.load` (already a test dep); a generated spec file.
+
+This is the go/no-go for Option B (generic `BundleTask`) vs Option A (per-model generated class). If `XnatApp.load` rejects the spec because `command.sources`/`sinks` name fields that are not static attrs fields on `BundleTask`, escalate to Option A (see design doc "Open items").
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_monai_specs.py`:
+
+```python
+def test_generated_spec_loads_as_xnatapp(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import scripts.monai_specs as ms
+    from pydra2app.xnat import XnatApp
+
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {
+            "sources": {"image": {"datatype": "medimage/nifti-gz-x",
+                                  "help": "in", "path": "network_data_format/inputs/image"}},
+            "sinks": {"pred": {"datatype": "medimage/nifti-gz-x",
+                               "help": "out", "path": "network_data_format/outputs/pred"}},
+            "parameters": {},
+        },
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    spec = mm.generate_spec(entry, bundle_dir=tmp_path / "bundle")
+    path = mm.write_spec(entry, spec)
+
+    image_spec = XnatApp.load(path)
+    assert image_spec.commands
+    assert image_spec.commands[0].name
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -k xnatapp -v`
+Expected: PASS. If it FAILS on field resolution, record the error and escalate to Option A per the design doc before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_monai_specs.py
+git commit -m "test(monai): assert generated spec loads as an XnatApp (Option B go/no-go)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Add dependency + scheduled GitHub Action
+
+**Files:**
+- Modify: `pyproject.toml:41` (add `pydra-compose-monai` to `test` deps)
+- Create: `.github/workflows/monai-sync.yml`
+
+**Interfaces:** none (CI wiring).
+
+- [ ] **Step 1: Add the dependency**
+
+In `pyproject.toml`, in the `[project.optional-dependencies]` `test = [...]` list, add `"pydra-compose-monai"` so the sync + tests can import it:
+
+```toml
+test = ["pytest >=6.2.5", "pytest-env>=0.6.2", "pytest-cov>=2.12.1", "frametree>=0.14.5", "xnat4tests>=0.3.14", "pydra2app>=0.18.8", "pydra2app-xnat>=0.8.2", "pydra-compose-monai"]
+```
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/monai-sync.yml`:
+
+```yaml
+name: Sync MONAI model specs
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"   # 03:00 UTC every Monday
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: monai-test
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+      - name: Generate/update MONAI specs
+        run: python -m scripts.monai_specs sync
+      - name: Open PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: monai-spec-sync
+          base: monai-test
+          title: "Update MONAI model specs"
+          commit-message: "chore(monai): sync model specs from Model Zoo"
+          body: "Automated MONAI Model Zoo spec sync. Review generated specs before merge."
+          add-paths: |
+            specs/**/monai/**
+```
+
+- [ ] **Step 3: Validate the workflow YAML**
+
+Run: `.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/monai-sync.yml'))"`
+Expected: no output (valid YAML).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml .github/workflows/monai-sync.yml
+git commit -m "ci(monai): add pydra-compose-monai dep and scheduled spec-sync workflow
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full regression + lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the new test module**
+
+Run: `.venv/bin/pytest tests/test_monai_specs.py -v`
+Expected: all tests pass.
+
+- [ ] **Step 2: Confirm the existing suite is unaffected**
+
+Run: `.venv/bin/pytest tests/test_monai.py -v` (this is the network/XNAT test; expect it to be skipped/collected as before — it must not be newly broken by our changes).
+Expected: same collection/skip behavior as before this work; no new import errors from `scripts/`.
+
+## Self-Review
+
+- **Spec coverage:** Component 2 (`MonaiModels` methods `fetch`/`filter`/`detect`/`generate`/`write`/`sync`) → Tasks 1–5. Whitelist + overlay control surfaces → Tasks 1 & 4. `monai/` namespace output → Task 1 `spec_path` + Task 5 `write_spec`. Option B go/no-go (`XnatApp.load`) → Task 6. Component 3 (scheduled PR-opening Action) → Task 7. Regression → Task 8. Depends-on Plan A's `spec_fragment`/`BundleTask` → Global Constraints + Task 7 dep. Complete.
+- **Placeholder scan:** No TBD/TODO; every code step shows full code and exact commands. The overlay email uses a generic placeholder address (no PII).
+- **Type consistency:** `WhitelistEntry` fields (`name/version/modality/species/region`) used consistently; `spec_fragment` return shape (`sources`/`sinks`/`parameters`) matches Plan A and every consumer here; `TASK_REF`/`configuration.bundle` strings match between impl and tests; `sync(download_bundle=...)` signature consistent between Task 5 impl, tests, and CLI (`mm._download`).
+- **py38 constraint:** `scripts/` uses `Optional`/`List`/`Dict`/`Callable` from `typing`, no `X | Y` unions — consistent with repo target.

--- a/docs/superpowers/specs/2026-07-10-monai-spec-generator-design.md
+++ b/docs/superpowers/specs/2026-07-10-monai-spec-generator-design.md
@@ -1,0 +1,150 @@
+# MONAI model registry + spec generator — design
+
+## Context
+
+The Australian Imaging Service `pipelines` repo builds container images for
+XNAT by way of `pydra2app`/`pipeline2app` YAML specs
+(`specs/australian-imaging-service/<modality>/<species>/<region>/<name>.yaml`).
+Today every spec points `command.task` at a conventional pydra-tasks package
+(e.g. FastSurfer, FSL). We want to add **MONAI Model Zoo bundles** as a first
+class source of pipelines.
+
+The sibling package **`pydra-compose-monai`** (`../pydra-compose-monai`, on
+PyPI) already turns a MONAI bundle on disk into a runnable
+`pydra.compose.base.Task` subclass: `define(bundle_path)` parses the bundle's
+`configs/metadata.json` (`network_data_format.inputs/outputs`), maps each field
+to a fileformats datatype, and builds a `MonaiTask`. Running the task loads
+`inference.json` and runs the bundle evaluator. What it does **not** have:
+YAML-spec serialization, and any Model Zoo *listing* / whitelist / version
+tracking.
+
+The goal: a scheduled process in `pipelines` that fetches the MONAI model list,
+filters it to a whitelist, detects new/updated models, generates/updates a
+`pipeline2app` spec per model, and writes those specs into the `specs/` tree so
+the existing `pydra2app xnat make` build path can turn them into XNAT images.
+
+This work targets the existing **`monai-test`** branch of `pipelines`.
+
+## Target spec contract (confirmed from pipeline2app/frametree source)
+
+- Specs are consumed by **`pipeline2app`** (module `pydra2app`), built with
+  `pydra2app xnat make <spec>`. `pipelines/tests/test_monai.py` already exercises
+  this via `XnatApp.load(SPEC_PATH)` + iterating `image_spec.commands`.
+- The **current 2.x schema** applies (not the older `schema_version: 1.0`
+  sample): top-level `commands:` is a **list**; per-command keys are `task`,
+  `operates_on`, `sources`, `sinks`, `parameters`, `configuration`.
+- **`command.task`** must resolve to an **importable subclass of
+  `pydra.compose.base.Task`** (`module:ClassName`) whose fields pipeline2app
+  introspects via `pydra.utils.get_fields`. A `MonaiTask` qualifies.
+- **`configuration`** is a dict of constant task-constructor kwargs not exposed
+  to the user; every key must be a real task input field. Passed at runtime as
+  `task(**configuration)`.
+- **`operates_on`** = the dataset row frequency (e.g. `session`); sinks must be
+  at that frequency.
+- Datatypes are fileformats MIME-like strings (e.g. `medimage/nifti-gz`).
+
+## Architecture
+
+Two repos; one small addition to `pydra-compose-monai`, the bulk in `pipelines`.
+
+### Division of responsibility
+
+- **pydra-compose-monai** adds the MONAI→fileformats *serialization* (see below)
+  so that mapping stays in one tested place, plus the generic parametric task
+  that specs point at.
+- **pipelines** owns the registry pipeline (`MonaiModels`), the whitelist, the
+  overlays, the generated specs, and the scheduled Action.
+
+### Execution model (decided)
+
+Each model's **bundle is baked into the image at build time** (downloaded and
+vendored during the build), and the spec's `command.task` points at a **generic
+parametric MONAI task** — Option B below — with the baked-in bundle directory
+supplied via `configuration: {bundle: /opt/bundles/<model>}`.
+
+**command.task binding — Option B (prototype) with Option A fallback:**
+- **B (prototype):** one hand-written class `pydra.compose.monai:BundleTask` for
+  all models; the specific bundle is selected via `configuration`. The
+  per-model `sources`/`sinks`/`parameters` come from the spec, generated from
+  the bundle. No per-model code generation.
+- **A (fallback):** if pipeline2app rejects spec-declared fields that are not
+  static attrs fields on the task, generate a real importable per-model class
+  (e.g. `pydra.tasks.monai:SpleenCtSegmentation`) with the bundle baked in.
+  Only `MonaiModels.generate_spec` changes.
+
+The go/no-go test for B vs A is whether `XnatApp.load(<generated spec>)` +
+`.commands` introspection succeeds — the assertion `test_monai.py` already makes.
+
+## Component 1 — addition to `pydra-compose-monai`
+
+One public function, serializing what `parse_monai_spec()` already computes:
+
+```python
+spec_fragment(bundle_path) -> {"sources": {...}, "sinks": {...}, "parameters": {...}}
+```
+
+- Emits fileformats datatype strings (`medimage/nifti-gz`), `help`, and output
+  `path`s — the per-command field block in 2.x vocabulary.
+- Reuses `parse_monai_spec` / `_map_type` / `_input_help` / `_output_help`
+  (`pydra/compose/monai/spec_parser.py`) — no new mapping logic.
+
+Plus the generic `BundleTask` (Option B) whose `bundle` input is set via the
+command `configuration`. (`MonaiTask` already resolves a bundle *directory*,
+`pydra/compose/monai/task.py:_resolve_bundle_dir`.)
+
+## Component 2 — `MonaiModels` (in `pipelines/scripts/monai_specs.py`)
+
+Placement: **`scripts/` for the PoC** (tooling that generates specs, excluded
+from the shipped package — `pyproject.toml` already excludes `scripts/` from
+mypy). Promote reusable pieces into `src/australianimagingservice/...` later.
+
+| Method | Responsibility | Depends on |
+|---|---|---|
+| `fetch_available()` | List Model Zoo bundles + latest versions | `monai.bundle` (`get_all_bundles_list`, `get_bundle_versions`) |
+| `filter_whitelist()` | Keep only whitelisted models | `scripts/monai_whitelist.yaml` |
+| `detect_changes()` | Diff available versions vs versions recorded in existing specs → new/updated set | existing `monai/` specs' `version` field |
+| `generate_spec(model)` | Download+vendor bundle → call `pydra_compose_monai.spec_fragment` → deep-merge with the model's overlay → full `XnatApp` 2.x spec dict | pydra-compose-monai, per-model overlay |
+| `write_spec(model, spec)` | Write to the `monai/` namespace path | PyYAML |
+| `sync()` | End-to-end; entry point the Action calls | — |
+
+**Control surfaces (hand-authored for the PoC):**
+- `scripts/monai_whitelist.yaml` — which models, optional version pins, and the
+  anatomy placement (modality/species/region) for each.
+- Per-model **overlay** — fields not derivable from a bundle: `title`,
+  `authors`, `docs.info_url`, `base_image`, `packages`, `operates_on`. The
+  generator deep-merges so MONAI-derived `sources`/`sinks` refresh each run
+  while hand-authored fields survive. This is the seam for later auto-generation
+  (swap overlay → template).
+
+### Spec output location (decided: dedicated `monai/` namespace)
+
+Generated specs land under a `monai/` subtree keyed by anatomy, e.g.
+`specs/australian-imaging-service/<modality>/<species>/<region>/monai/<model>.yaml`.
+Keeping auto-generated specs in their own namespace lets the Action regenerate/
+overwrite them safely without touching hand-authored specs.
+
+## Component 3 — scheduled GitHub Action
+
+- `cron`-scheduled workflow in `pipelines/.github/workflows/`.
+- Runs `python -m scripts.monai_specs sync`.
+- Opens a **PR** with changed specs (not a direct push) so regenerated specs are
+  reviewed before merge.
+
+## Verification
+
+- **Unit** — test each `MonaiModels` method against a synthetic bundle (reuse
+  pydra-compose-monai's synthetic-bundle fixtures); no network.
+- **Contract (go/no-go for B vs A)** — `XnatApp.load(<generated spec>)` succeeds
+  and `.commands` introspects, matching `pipelines/tests/test_monai.py`.
+- **Build** — `pydra2app xnat make <spec> --generate-only` (the `SKIP_BUILD`
+  path already in `test_monai.py`).
+- **End-to-end** (optional, network) — full `--build` + XNAT container-service
+  launch, as `test_monai.py` already drives.
+
+## Open items / later work
+
+- Auto-generate overlay metadata (replace hand-authored overlays with a MONAI
+  runtime template + repo defaults).
+- Decide baked-in bundle path convention (`/opt/bundles/<model>`) and how the
+  build downloads/vendors the bundle (neurodocker `packages` vs a build hook).
+- Confirm Model Zoo listing API surface across the pinned `monai` version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["black", "pre-commit", "codespell", "flake8", "flake8-pyproject"]
-test = ["pytest >=6.2.5", "pytest-env>=0.6.2", "pytest-cov>=2.12.1", "frametree>=0.14.5", "xnat4tests>=0.3.14", "pydra2app>=0.18.8", "pydra2app-xnat>=0.8.2"]
+test = ["pytest >=6.2.5", "pytest-env>=0.6.2", "pytest-cov>=2.12.1", "frametree>=0.14.5", "xnat4tests>=0.3.14", "pydra2app>=0.18.8", "pydra2app-xnat>=0.8.2", "pydra-compose-monai >=0.1.3"]
 
 
 [project.urls]

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -2,7 +2,7 @@
 import re
 import typing as ty
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import yaml
 from monai.bundle import get_all_bundles_list
@@ -192,3 +192,62 @@ class MonaiModels:
         merged = _deep_merge(overlay, spec)
         merged.pop("operates_on", None)  # consumed into the command
         return merged
+
+    def write_spec(self, entry: WhitelistEntry, spec: dict) -> Path:
+        path = self.spec_path(entry)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(spec, sort_keys=False))
+        return path
+
+    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
+        """Full pipeline: fetch → filter → detect → codegen + generate → write.
+
+        For each changed model: download the bundle, write the committed
+        per-model task module, generate the spec (which references that
+        module), and write the spec. Returns the spec paths written.
+
+        ``download_bundle`` maps an entry to a local bundle root directory
+        (injected so tests need no network; production passes ``self._download``).
+        """
+        available = self.fetch_available()
+        whitelisted = self.filter_whitelist(available)
+        changed = self.detect_changes(whitelisted)
+        written: List[Path] = []
+        for entry in changed:
+            bundle_dir = download_bundle(entry)
+            self.write_task_module(entry)
+            spec = self.generate_spec(entry, bundle_dir)
+            written.append(self.write_spec(entry, spec))
+        return written
+
+    def _download(self, entry: WhitelistEntry) -> Path:
+        """Download a bundle from the Model Zoo into ``<root>/.monai-bundles``."""
+        from monai.bundle import download
+
+        dest = self.root / ".monai-bundles"
+        dest.mkdir(parents=True, exist_ok=True)
+        download(name=entry.name, version=entry.version, bundle_dir=str(dest))
+        return dest / entry.name
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sync MONAI Model Zoo specs")
+    parser.add_argument("command", choices=["sync"])
+    parser.add_argument("--root", type=Path, default=Path(__file__).parent.parent)
+    parser.add_argument(
+        "--whitelist", type=Path,
+        default=Path(__file__).parent / "monai_whitelist.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    mm = MonaiModels(root=args.root, whitelist_path=args.whitelist)
+    written = mm.sync(download_bundle=mm._download)
+    for path in written:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -1,0 +1,50 @@
+"""Generate pipeline2app XNAT specs from whitelisted MONAI Model Zoo bundles."""
+import typing as ty
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+
+class WhitelistEntry(ty.NamedTuple):
+    name: str
+    version: Optional[str]
+    modality: str
+    species: str
+    region: str
+
+
+class MonaiModels:
+    """Fetch, filter, generate and write MONAI-bundle pipeline specs."""
+
+    def __init__(self, root: Path, whitelist_path: Path) -> None:
+        self.root = Path(root)
+        self.whitelist_path = Path(whitelist_path)
+
+    def whitelist(self) -> List[WhitelistEntry]:
+        data = yaml.safe_load(self.whitelist_path.read_text()) or {}
+        models: Dict[str, dict] = data.get("models", {})
+        entries: List[WhitelistEntry] = []
+        for name, cfg in models.items():
+            entries.append(
+                WhitelistEntry(
+                    name=name,
+                    version=cfg.get("version"),
+                    modality=cfg["modality"],
+                    species=cfg["species"],
+                    region=cfg["region"],
+                )
+            )
+        return entries
+
+    def spec_path(self, entry: WhitelistEntry) -> Path:
+        return (
+            self.root
+            / "specs"
+            / "australian-imaging-service"
+            / entry.modality
+            / entry.species
+            / entry.region
+            / "monai"
+            / f"{entry.name}.yaml"
+        )

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -1,10 +1,14 @@
 """Generate pipeline2app XNAT specs from whitelisted MONAI Model Zoo bundles."""
+import re
 import typing as ty
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
 from monai.bundle import get_all_bundles_list
+
+BAKED_BUNDLE_ROOT = "/opt/bundles"
+PACKAGE = "australianimagingservice"
 
 
 class WhitelistEntry(ty.NamedTuple):
@@ -84,3 +88,51 @@ class MonaiModels:
             if self.existing_version(entry) != entry.version:
                 changed.append(entry)
         return changed
+
+    def class_name(self, entry: WhitelistEntry) -> str:
+        """CamelCase Python class name derived from the model name."""
+        words = re.split(r"[^a-zA-Z0-9]+", entry.name)
+        return "".join(w.capitalize() for w in words if w)
+
+    def _module_parts(self, entry: WhitelistEntry) -> List[str]:
+        return [PACKAGE, entry.modality, entry.species, entry.region, "monai", entry.name]
+
+    def task_module_path(self, entry: WhitelistEntry) -> Path:
+        parts = self._module_parts(entry)
+        return self.root.joinpath("src", *parts).with_suffix(".py")
+
+    def task_module_ref(self, entry: WhitelistEntry) -> str:
+        dotted = ".".join(self._module_parts(entry))
+        return f"{dotted}:{self.class_name(entry)}"
+
+    def write_task_module(self, entry: WhitelistEntry) -> Path:
+        """Generate a committed per-model task module (define()-built class).
+
+        The class bakes in the in-image bundle path so command.task can
+        reference it directly with no runtime configuration.
+        """
+        path = self.task_module_path(entry)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Ensure every generated package directory from the model's package
+        # dir up to (and including) <root>/src/ is importable.
+        src_root = self.root / "src"
+        pkg_dir = path.parent
+        package_dirs = [pkg_dir]
+        while pkg_dir != src_root:
+            pkg_dir = pkg_dir.parent
+            package_dirs.append(pkg_dir)
+        for pkg_dir in package_dirs:
+            init = pkg_dir / "__init__.py"
+            if not init.exists():
+                init.write_text("")
+
+        bundle_path = f"{BAKED_BUNDLE_ROOT}/{entry.name}"
+        cls = self.class_name(entry)
+        path.write_text(
+            '"""Auto-generated MONAI task module. Do not edit by hand."""\n'
+            "from pydra.compose import monai\n\n"
+            f'BUNDLE_PATH = "{bundle_path}"\n\n'
+            f'{cls} = monai.define(BUNDLE_PATH, name="{cls}")\n'
+        )
+        return path

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -68,3 +68,19 @@ class MonaiModels:
             / "monai"
             / f"{entry.name}.yaml"
         )
+
+    def existing_version(self, entry: WhitelistEntry) -> Optional[str]:
+        path = self.spec_path(entry)
+        if not path.is_file():
+            return None
+        data = yaml.safe_load(path.read_text()) or {}
+        version = data.get("version")
+        return str(version) if version is not None else None
+
+    def detect_changes(self, entries: List[WhitelistEntry]) -> List[WhitelistEntry]:
+        """Return entries with no spec yet, or whose version differs from the spec."""
+        changed: List[WhitelistEntry] = []
+        for entry in entries:
+            if self.existing_version(entry) != entry.version:
+                changed.append(entry)
+        return changed

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -41,13 +41,11 @@ class MonaiModels:
     def fetch_available(self) -> Dict[str, str]:
         """Return ``{bundle_name: latest_version}`` from the MONAI Model Zoo.
 
-        ``get_all_bundles_list`` returns ``(name, version)`` pairs newest-first;
-        the first occurrence of each name is its latest version.
+        ``monai.bundle.get_all_bundles_list()`` returns one
+        ``(bundle_name, latest_version)`` tuple per bundle (already reduced to
+        the latest version per bundle), so we build the mapping directly.
         """
-        available: Dict[str, str] = {}
-        for name, version in get_all_bundles_list():
-            available.setdefault(name, version)
-        return available
+        return {name: version for name, version in get_all_bundles_list()}
 
     def filter_whitelist(self, available: Dict[str, str]) -> List[WhitelistEntry]:
         """Keep whitelist entries present in ``available``; fill unpinned versions."""

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -6,9 +6,22 @@ from typing import Dict, List, Optional
 
 import yaml
 from monai.bundle import get_all_bundles_list
+from pydra.compose.monai import spec_fragment
 
 BAKED_BUNDLE_ROOT = "/opt/bundles"
 PACKAGE = "australianimagingservice"
+OVERLAYS_DIR = Path(__file__).parent / "overlays"
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursive merge; ``override`` wins on scalar conflicts."""
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
 
 
 class WhitelistEntry(ty.NamedTuple):
@@ -136,3 +149,46 @@ class MonaiModels:
             f'{cls} = monai.define(BUNDLE_PATH, name="{cls}")\n'
         )
         return path
+
+    def overlay_path(self, entry: WhitelistEntry) -> Path:
+        return OVERLAYS_DIR / f"{entry.name}.yaml"
+
+    def generate_spec(self, entry: WhitelistEntry, bundle_dir: Path) -> dict:
+        """Build a full pipeline2app XNAT spec dict for a model.
+
+        Combines the bundle-derived field fragment with the hand-authored
+        overlay (title/authors/docs/base_image/packages/operates_on).
+        command.task references the committed generated per-model class
+        (see write_task_module); the bundle is baked into that class, so
+        the command needs no configuration.
+        """
+        overlay = yaml.safe_load(self.overlay_path(entry).read_text()) or {}
+        fragment = spec_fragment(bundle_dir)
+
+        # Rewrite sink paths from bundle metadata paths to frametree store paths.
+        sinks = {}
+        for out_name, sink in fragment["sinks"].items():
+            sink = dict(sink)
+            sink["path"] = f"monai/{entry.name}/{out_name}"
+            sinks[out_name] = sink
+
+        operates_on = overlay.get("operates_on", "session")
+        command = {
+            "task": self.task_module_ref(entry),
+            "operates_on": operates_on,
+            "configuration": {},
+            "sources": fragment["sources"],
+            "sinks": sinks,
+            "parameters": fragment["parameters"],
+        }
+
+        spec = {
+            "name": entry.name,
+            "version": entry.version,
+            "commands": [command],
+        }
+        # overlay supplies title/authors/docs/base_image/packages; it must not
+        # override name/version/commands, so merge overlay UNDER the core spec.
+        merged = _deep_merge(overlay, spec)
+        merged.pop("operates_on", None)  # consumed into the command
+        return merged

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -8,7 +8,6 @@ import yaml
 from monai.bundle import get_all_bundles_list
 from pydra.compose.monai import spec_fragment
 
-BAKED_BUNDLE_ROOT = "/opt/bundles"
 PACKAGE = "australianimagingservice"
 OVERLAYS_DIR = Path(__file__).parent / "overlays"
 
@@ -118,34 +117,44 @@ class MonaiModels:
         dotted = ".".join(self._module_parts(entry))
         return f"{dotted}:{self.class_name(entry)}"
 
+    def bundle_vendor_dir(self, entry: WhitelistEntry) -> Path:
+        """Directory where the model's bundle is vendored, beside its module."""
+        return self.task_module_path(entry).parent / f"{entry.name}_bundle"
+
     def write_task_module(self, entry: WhitelistEntry) -> Path:
         """Generate a committed per-model task module (define()-built class).
 
-        The class bakes in the in-image bundle path so command.task can
-        reference it directly with no runtime configuration.
+        The class builds itself from the bundle vendored beside this module
+        (``<model>_bundle/``), using a module-relative path so it resolves
+        identically on the build host (CI / --generate-only) and inside the
+        built image. pipeline2app imports and introspects this class eagerly
+        at spec-load / Dockerfile-generation time, so the bundle must be
+        present next to the module — which is why sync() vendors it (Task 6).
         """
         path = self.task_module_path(entry)
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Ensure every generated package directory from the model's package
-        # dir up to (and including) <root>/src/ is importable.
+        # Ensure every generated package directory is importable.
         src_root = self.root / "src"
+        pkg_dirs = []
         pkg_dir = path.parent
-        package_dirs = [pkg_dir]
-        while pkg_dir != src_root:
+        while True:
+            pkg_dirs.append(pkg_dir)
+            if pkg_dir == src_root:
+                break
             pkg_dir = pkg_dir.parent
-            package_dirs.append(pkg_dir)
-        for pkg_dir in package_dirs:
-            init = pkg_dir / "__init__.py"
+        for d in pkg_dirs:
+            init = d / "__init__.py"
             if not init.exists():
                 init.write_text("")
 
-        bundle_path = f"{BAKED_BUNDLE_ROOT}/{entry.name}"
         cls = self.class_name(entry)
+        bundle_dirname = f"{entry.name}_bundle"
         path.write_text(
             '"""Auto-generated MONAI task module. Do not edit by hand."""\n'
+            "from pathlib import Path\n"
             "from pydra.compose import monai\n\n"
-            f'BUNDLE_PATH = "{bundle_path}"\n\n'
+            f'BUNDLE_PATH = Path(__file__).parent / "{bundle_dirname}"\n\n'
             f'{cls} = monai.define(BUNDLE_PATH, name="{cls}")\n'
         )
         return path
@@ -199,12 +208,29 @@ class MonaiModels:
         path.write_text(yaml.safe_dump(spec, sort_keys=False))
         return path
 
-    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
-        """Full pipeline: fetch → filter → detect → codegen + generate → write.
+    def vendor_bundle(self, entry: WhitelistEntry, bundle_dir: Path) -> Path:
+        """Copy the downloaded bundle to sit beside the generated module.
 
-        For each changed model: download the bundle, write the committed
-        per-model task module, generate the spec (which references that
-        module), and write the spec. Returns the spec paths written.
+        The generated task module reads the bundle via a module-relative path
+        (``Path(__file__).parent / "<model>_bundle"``), so the bundle must be
+        committed there. Idempotent: replaces any existing vendored copy.
+        """
+        import shutil
+
+        dest = self.bundle_vendor_dir(entry)
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(bundle_dir, dest)
+        return dest
+
+    def sync(self, download_bundle: Callable[[WhitelistEntry], Path]) -> List[Path]:
+        """Full pipeline: fetch → filter → detect → vendor + codegen + generate → write.
+
+        For each changed model: download the bundle, vendor it beside the
+        generated module, write the committed per-model task module, generate
+        the spec (which references that module + vendored bundle), and write
+        the spec. Returns the spec paths written.
 
         ``download_bundle`` maps an entry to a local bundle root directory
         (injected so tests need no network; production passes ``self._download``).
@@ -216,6 +242,7 @@ class MonaiModels:
         for entry in changed:
             bundle_dir = download_bundle(entry)
             self.write_task_module(entry)
+            self.vendor_bundle(entry, bundle_dir)
             spec = self.generate_spec(entry, bundle_dir)
             written.append(self.write_spec(entry, spec))
         return written

--- a/scripts/monai_specs.py
+++ b/scripts/monai_specs.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
+from monai.bundle import get_all_bundles_list
 
 
 class WhitelistEntry(ty.NamedTuple):
@@ -36,6 +37,27 @@ class MonaiModels:
                 )
             )
         return entries
+
+    def fetch_available(self) -> Dict[str, str]:
+        """Return ``{bundle_name: latest_version}`` from the MONAI Model Zoo.
+
+        ``get_all_bundles_list`` returns ``(name, version)`` pairs newest-first;
+        the first occurrence of each name is its latest version.
+        """
+        available: Dict[str, str] = {}
+        for name, version in get_all_bundles_list():
+            available.setdefault(name, version)
+        return available
+
+    def filter_whitelist(self, available: Dict[str, str]) -> List[WhitelistEntry]:
+        """Keep whitelist entries present in ``available``; fill unpinned versions."""
+        kept: List[WhitelistEntry] = []
+        for entry in self.whitelist():
+            if entry.name not in available:
+                continue
+            version = entry.version or available[entry.name]
+            kept.append(entry._replace(version=version))
+        return kept
 
     def spec_path(self, entry: WhitelistEntry) -> Path:
         return (

--- a/scripts/monai_whitelist.yaml
+++ b/scripts/monai_whitelist.yaml
@@ -1,0 +1,8 @@
+# MONAI Model Zoo models to publish as AIS pipelines.
+# Each entry: version pin (null = latest) and anatomy placement in specs/ tree.
+models:
+  spleen_ct_segmentation:
+    version: null
+    modality: ct
+    species: human
+    region: abdomen

--- a/scripts/overlays/spleen_ct_segmentation.yaml
+++ b/scripts/overlays/spleen_ct_segmentation.yaml
@@ -4,6 +4,9 @@ authors:
     email: monai.contact@gmail.com
 docs:
   info_url: https://monai.io/model-zoo.html
+  description: >
+    Spleen CT segmentation MONAI bundle from the MONAI Model Zoo, wrapped as a
+    Pydra task and packaged for the Australian Imaging Service.
 base_image:
   name: projectmonai/monai
   tag: latest

--- a/scripts/overlays/spleen_ct_segmentation.yaml
+++ b/scripts/overlays/spleen_ct_segmentation.yaml
@@ -1,0 +1,14 @@
+title: MONAI Spleen CT Segmentation
+authors:
+  - name: MONAI Consortium
+    email: monai.contact@gmail.com
+docs:
+  info_url: https://monai.io/model-zoo.html
+base_image:
+  name: projectmonai/monai
+  tag: latest
+  package_manager: apt
+packages:
+  pip:
+    pydra-compose-monai:
+operates_on: session

--- a/specs/australian-imaging-service/ct/human/lung/nodule_detection.yaml
+++ b/specs/australian-imaging-service/ct/human/lung/nodule_detection.yaml
@@ -16,15 +16,15 @@ docs:
     User-facing description goes here
   info_url: https://github.com/Project-MONAI/model-zoo
 packages:
-  system:
+  # system:
     # - libglib2.0-0  # Replace with any required packages
   # conda:
   #   tesseract: 5.5.0
   pip:
-    pydra-compose-monai: 
-    nibabel: "5.2.1",
-    pytorch-ignite: "0.4.11",
-    torchvision: "0.19.0",
+    pydra-compose-monai: 0.1.1
+    nibabel: "5.2.1"
+    pytorch-ignite: "0.4.11"
+    torchvision: "0.19.0"
     tensorboard: "2.17.0"
     torch: 2.4.0
     numpy: 1.24.4

--- a/specs/australian-imaging-service/ct/human/lung/nodule_detection.yaml
+++ b/specs/australian-imaging-service/ct/human/lung/nodule_detection.yaml
@@ -1,0 +1,37 @@
+schema_version: '2.0'
+title: CT Lung nodule detection
+version: "0.6.10"
+# base_image:
+#   # Chose a NeuroDesk FSL container as the base
+#   name: deepmi/fastsurfer
+#   package_manager: apt # It is not obvious from the base image what the package manager is
+#   tag: gpu-latest
+authors:
+  - name: Gary S. Browne
+    email: gary.browne@sydney.edu.au
+  - name: Thomas G. Close
+    email: tom.g.close@gmail.com
+docs:
+  description: >-
+    User-facing description goes here
+  info_url: https://github.com/Project-MONAI/model-zoo
+packages:
+  system:
+    # - libglib2.0-0  # Replace with any required packages
+  # conda:
+  #   tesseract: 5.5.0
+  pip:
+    pydra-compose-monai: 
+    nibabel: "5.2.1",
+    pytorch-ignite: "0.4.11",
+    torchvision: "0.19.0",
+    tensorboard: "2.17.0"
+    torch: 2.4.0
+    numpy: 1.24.4
+    monai: 1.4.0
+commands:
+  nodule-detection:
+    operates_on: medimage/session
+    task:
+      type: monai
+      bundle: lung_nodule_ct_detection

--- a/tests/test_monai.py
+++ b/tests/test_monai.py
@@ -1,0 +1,113 @@
+import json
+import typing as ty
+from pathlib import Path
+from pydra2app.core.cli import make
+from pydra2app.xnat import XnatApp
+from frametree.core.utils import show_cli_trace
+from frametree.xnat import Xnat
+from pydra2app.xnat.deploy import install_and_launch_xnat_cs_command
+from conftest import upload_test_dataset_to_xnat, test_data_dir
+
+PKG_DIR = Path(__file__).parent.parent
+
+SPEC_PATH = (
+    PKG_DIR
+    / "specs"
+    / "australian-imaging-service"
+    / "ct"
+    / "human"
+    / "lung"
+    / "nodule_detection.yaml"
+)
+
+
+
+RESOURCES_DIR = PKG_DIR / "resources"
+
+SKIP_BUILD = False
+
+
+def test_monai_app(
+    run_prefix: str,
+    xnat_connect: ty.Any,
+    xnat_repository: Xnat,
+    cli_runner: ty.Callable[..., ty.Any],
+    tmp_path: Path,
+):
+
+    build_dir = tmp_path / "build"
+
+    build_dir.mkdir(exist_ok=True, parents=True)
+
+    project_id = f"{run_prefix}cthumanlungnoduledetection"
+
+    test_data = (
+        test_data_dir / "specs" / "ct" / "human" / "lung" / "nodule_detection"
+    )
+    upload_test_dataset_to_xnat(project_id, test_data, xnat_connect)
+
+    if SKIP_BUILD:
+        build_arg = "--generate-only"
+    else:
+        build_arg = "--build"
+
+    result = cli_runner(
+        make,
+        [
+            "xnat",
+            str(SPEC_PATH),
+            "--build-dir",
+            str(build_dir),
+            build_arg,
+            "--resources-dir",
+            str(RESOURCES_DIR),
+            "--for-localhost",
+            "--use-local-packages",
+            "--raise-errors",
+        ],
+    )
+
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    image_spec = XnatApp.load(SPEC_PATH)
+
+    command_inputs = {
+        "nodule_detection": {
+            "T1w": "t1_mprage_sag_p2_iso_1_ADNI",
+            "Parcellation": "desikan",
+            "FastSurferBatchSize": 4,
+            "FastSurferNThreads": 4,
+        },
+    }
+
+    with xnat_connect() as xlogin:
+
+        for command_obj in image_spec.commands:
+            with open(build_dir / "xnat_commands" / (command_obj.name + ".json")) as f:
+                command_json = json.load(f)
+            command_json["name"] = command_json["label"] = (
+                image_spec.name + command_obj.name + run_prefix
+            )
+
+            test_xsession = next(iter(xlogin.projects[project_id].experiments.values()))
+
+            inputs_json = command_inputs[command_obj.name]
+            inputs_json["pydra2app_flags"] = (
+                "--worker debug "
+                "--work /work "  # NB: work dir moved inside container due to file-locking issue on some mounted volumes (see https://github.com/tox-dev/py-filelock/issues/147)
+                "--dataset-name default "
+                "--logger frametree debug "
+                "--logger frametree-xnat debug "
+                "--logger pydra2app debug "
+                "--logger pydra2app-xnat debug "
+            )
+
+            workflow_id, status, out_str = install_and_launch_xnat_cs_command(
+                command_json=command_json,
+                project_id=project_id,
+                session_id=test_xsession.id,
+                inputs=inputs_json,
+                xlogin=xlogin,
+                timeout=30000,
+            )
+            assert status == "Complete", f"Workflow {workflow_id} failed.\n{out_str}"

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -125,3 +125,38 @@ def test_detect_changes_flags_new_and_updated(tmp_path, whitelist_file):
     # Spec at older version -> flagged (updated)
     _write_spec(mm.spec_path(entry), "0.5.0")
     assert mm.detect_changes([entry]) == [entry]
+
+
+def test_class_name_is_camelcase(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.class_name(entry) == "SpleenCtSegmentation"
+
+
+def test_task_module_ref_and_path(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.task_module_ref(entry) == (
+        "australianimagingservice.ct.human.abdomen.monai."
+        "spleen_ct_segmentation:SpleenCtSegmentation"
+    )
+    assert mm.task_module_path(entry) == (
+        tmp_path / "src" / "australianimagingservice" / "ct" / "human"
+        / "abdomen" / "monai" / "spleen_ct_segmentation.py"
+    )
+
+
+def test_write_task_module_emits_importable_define_call(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    path = mm.write_task_module(entry)
+    assert path == mm.task_module_path(entry)
+    text = path.read_text()
+    # references pydra-compose-monai define, bakes the bundle path, names the class
+    assert "from pydra.compose import monai" in text
+    assert '"/opt/bundles/spleen_ct_segmentation"' in text
+    assert "SpleenCtSegmentation = monai.define(" in text
+    # every generated package dir has an __init__.py so the dotted ref imports
+    assert (path.parent / "__init__.py").is_file()
+    # intermediate directories up to src/ are also importable packages
+    assert (tmp_path / "src" / "australianimagingservice" / "__init__.py").is_file()

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -89,6 +89,8 @@ def test_filter_whitelist_respects_pin(tmp_path: Path):
 def test_fetch_available_uses_monai_api(tmp_path, whitelist_file, monkeypatch):
     import scripts.monai_specs as ms
 
+    # get_all_bundles_list() returns one (bundle_name, latest_version) tuple
+    # per bundle, already reduced to the latest version.
     monkeypatch.setattr(
         ms, "get_all_bundles_list",
         lambda **kw: [("spleen_ct_segmentation", "0.5.3")],

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -160,3 +160,59 @@ def test_write_task_module_emits_importable_define_call(tmp_path, whitelist_file
     assert (path.parent / "__init__.py").is_file()
     # intermediate directories up to src/ are also importable packages
     assert (tmp_path / "src" / "australianimagingservice" / "__init__.py").is_file()
+
+
+@pytest.fixture
+def overlay_dir(tmp_path: Path, monkeypatch) -> Path:
+    import scripts.monai_specs as ms
+
+    d = tmp_path / "overlays"
+    d.mkdir()
+    (d / "spleen_ct_segmentation.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "title": "MONAI Spleen CT Segmentation",
+                "authors": [{"name": "MONAI Consortium", "email": "x@example.org"}],
+                "docs": {"info_url": "https://monai.io/model-zoo.html"},
+                "base_image": {"name": "projectmonai/monai", "tag": "latest",
+                               "package_manager": "apt"},
+                "packages": {"pip": {"pydra-compose-monai": None}},
+                "operates_on": "session",
+            }
+        )
+    )
+    monkeypatch.setattr(ms, "OVERLAYS_DIR", d)
+    return d
+
+
+def test_generate_spec_shape(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {
+            "sources": {"image": {"datatype": "medimage/nifti-gz-x",
+                                  "help": "in", "path": "network_data_format/inputs/image"}},
+            "sinks": {"pred": {"datatype": "medimage/nifti-gz-x",
+                               "help": "out", "path": "network_data_format/outputs/pred"}},
+            "parameters": {},
+        },
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    spec = mm.generate_spec(entry, bundle_dir=tmp_path / "bundle")
+
+    assert spec["title"] == "MONAI Spleen CT Segmentation"
+    assert spec["version"] == "0.5.3"
+    assert isinstance(spec["commands"], list) and len(spec["commands"]) == 1
+    cmd = spec["commands"][0]
+    assert cmd["task"] == (
+        "australianimagingservice.ct.human.abdomen.monai."
+        "spleen_ct_segmentation:SpleenCtSegmentation"
+    )
+    # bundle is baked into the generated class, so configuration is empty
+    assert cmd["configuration"] == {}
+    assert cmd["operates_on"] == "session"
+    assert cmd["sources"]["image"]["datatype"] == "medimage/nifti-gz-x"
+    # sink path rewritten to the frametree store path
+    assert cmd["sinks"]["pred"]["path"] == "monai/spleen_ct_segmentation/pred"

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR.parent))
+
+from scripts.monai_specs import MonaiModels, WhitelistEntry  # noqa: E402
+
+
+@pytest.fixture
+def whitelist_file(tmp_path: Path) -> Path:
+    p = tmp_path / "monai_whitelist.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "spleen_ct_segmentation": {
+                        "version": None,
+                        "modality": "ct",
+                        "species": "human",
+                        "region": "abdomen",
+                    }
+                }
+            }
+        )
+    )
+    return p
+
+
+def test_whitelist_parses_entries(tmp_path: Path, whitelist_file: Path):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entries = mm.whitelist()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e == WhitelistEntry("spleen_ct_segmentation", None, "ct", "human", "abdomen")
+
+
+def test_spec_path_follows_monai_namespace(tmp_path: Path, whitelist_file: Path):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    expected = (
+        tmp_path
+        / "specs"
+        / "australian-imaging-service"
+        / "ct"
+        / "human"
+        / "abdomen"
+        / "monai"
+        / "spleen_ct_segmentation.yaml"
+    )
+    assert mm.spec_path(entry) == expected

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -98,3 +98,30 @@ def test_fetch_available_uses_monai_api(tmp_path, whitelist_file, monkeypatch):
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
     available = mm.fetch_available()
     assert available["spleen_ct_segmentation"] == "0.5.3"
+
+
+def _write_spec(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({"name": path.stem, "version": version}))
+
+
+def test_existing_version_none_when_missing(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.existing_version(entry) is None
+
+
+def test_detect_changes_flags_new_and_updated(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+
+    # No spec yet -> flagged as changed (new)
+    assert mm.detect_changes([entry]) == [entry]
+
+    # Spec at same version -> not flagged
+    _write_spec(mm.spec_path(entry), "0.5.3")
+    assert mm.detect_changes([entry]) == []
+
+    # Spec at older version -> flagged (updated)
+    _write_spec(mm.spec_path(entry), "0.5.0")
+    assert mm.detect_changes([entry]) == [entry]

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -52,3 +52,47 @@ def test_spec_path_follows_monai_namespace(tmp_path: Path, whitelist_file: Path)
         / "spleen_ct_segmentation.yaml"
     )
     assert mm.spec_path(entry) == expected
+
+
+def test_filter_whitelist_keeps_available_and_fills_latest(
+    tmp_path: Path, whitelist_file: Path
+):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    available = {"spleen_ct_segmentation": "0.5.3", "other_model": "1.0.0"}
+    kept = mm.filter_whitelist(available)
+    assert len(kept) == 1
+    assert kept[0].name == "spleen_ct_segmentation"
+    assert kept[0].version == "0.5.3"  # pin was None -> latest filled in
+
+
+def test_filter_whitelist_respects_pin(tmp_path: Path):
+    wl = tmp_path / "wl.yaml"
+    wl.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "spleen_ct_segmentation": {
+                        "version": "0.5.0",
+                        "modality": "ct",
+                        "species": "human",
+                        "region": "abdomen",
+                    }
+                }
+            }
+        )
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=wl)
+    kept = mm.filter_whitelist({"spleen_ct_segmentation": "0.5.3"})
+    assert kept[0].version == "0.5.0"
+
+
+def test_fetch_available_uses_monai_api(tmp_path, whitelist_file, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(
+        ms, "get_all_bundles_list",
+        lambda **kw: [("spleen_ct_segmentation", "0.5.3")],
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    available = mm.fetch_available()
+    assert available["spleen_ct_segmentation"] == "0.5.3"

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -146,20 +147,29 @@ def test_task_module_ref_and_path(tmp_path, whitelist_file):
     )
 
 
-def test_write_task_module_emits_importable_define_call(tmp_path, whitelist_file):
+def test_bundle_vendor_dir_beside_module(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]
+    assert mm.bundle_vendor_dir(entry) == (
+        mm.task_module_path(entry).parent / "spleen_ct_segmentation_bundle"
+    )
+
+
+def test_write_task_module_uses_module_relative_bundle(tmp_path, whitelist_file):
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
     entry = mm.whitelist()[0]
     path = mm.write_task_module(entry)
     assert path == mm.task_module_path(entry)
     text = path.read_text()
-    # references pydra-compose-monai define, bakes the bundle path, names the class
+    # references pydra-compose-monai define, uses a module-relative bundle path
+    # (NOT an absolute /opt/bundles path), and names the class
     assert "from pydra.compose import monai" in text
-    assert '"/opt/bundles/spleen_ct_segmentation"' in text
+    assert "Path(__file__).parent" in text
+    assert '"spleen_ct_segmentation_bundle"' in text
+    assert "/opt/bundles" not in text
     assert "SpleenCtSegmentation = monai.define(" in text
     # every generated package dir has an __init__.py so the dotted ref imports
     assert (path.parent / "__init__.py").is_file()
-    # intermediate directories up to src/ are also importable packages
-    assert (tmp_path / "src" / "australianimagingservice" / "__init__.py").is_file()
 
 
 @pytest.fixture
@@ -236,15 +246,75 @@ def test_sync_writes_only_changed(tmp_path, whitelist_file, overlay_dir, monkeyp
         ms, "spec_fragment",
         lambda bundle: {"sources": {}, "sinks": {}, "parameters": {}},
     )
+
+    # A fake downloaded bundle dir for vendor_bundle to copy.
+    fake_bundle = tmp_path / "downloaded_bundle"
+    (fake_bundle / "configs").mkdir(parents=True)
+    (fake_bundle / "configs" / "metadata.json").write_text("{}")
+
     mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
 
-    written = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    written = mm.sync(download_bundle=lambda entry: fake_bundle)
     assert len(written) == 1
     assert written[0].is_file()
-    # sync also emitted the committed per-model task module
+    # sync also emitted the committed per-model task module ...
     entry = mm.whitelist()[0]._replace(version="0.5.3")
     assert mm.task_module_path(entry).is_file()
+    # ... and vendored the bundle beside it
+    assert (mm.bundle_vendor_dir(entry) / "configs" / "metadata.json").is_file()
 
     # Second run: version unchanged -> nothing written
-    written2 = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    written2 = mm.sync(download_bundle=lambda entry: fake_bundle)
     assert written2 == []
+
+
+def _make_synthetic_bundle(dest: Path) -> Path:
+    configs = dest / "configs"
+    configs.mkdir(parents=True, exist_ok=True)
+    (configs / "metadata.json").write_text(json.dumps({
+        "name": "SpleenCtSegmentation",
+        "network_data_format": {
+            "inputs": {"image": {"type": "image", "modality": "CT"}},
+            "outputs": {"pred": {"type": "image", "format": "segmentation"}},
+        },
+    }))
+    (configs / "inference.json").write_text(json.dumps({
+        "postprocessing": {"_target_": "Compose", "transforms": [
+            {"_target_": "SaveImaged", "keys": ["pred"], "output_postfix": "seg"}
+        ]}
+    }))
+    return dest
+
+
+def test_generated_spec_loads_as_xnatapp(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import importlib
+    import scripts.monai_specs as ms
+    from pydra2app.xnat import XnatApp
+
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {
+            "sources": {"image": {"datatype": "medimage/nifti-gz-x",
+                                  "help": "in", "path": "network_data_format/inputs/image"}},
+            "sinks": {"pred": {"datatype": "medimage/nifti-gz-x",
+                               "help": "out", "path": "network_data_format/outputs/pred"}},
+            "parameters": {},
+        },
+    )
+    bundle = _make_synthetic_bundle(tmp_path / "downloaded")
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+
+    # Full sync path: writes the module, vendors the bundle beside it, writes the spec.
+    written = mm.sync(download_bundle=lambda entry: bundle)
+    assert len(written) == 1
+    spec_path = written[0]
+
+    # Make the generated module importable, then load the spec (eager task import).
+    monkeypatch.syspath_prepend(str(tmp_path / "src"))
+    importlib.invalidate_caches()
+
+    image_spec = XnatApp.load(spec_path)
+    assert image_spec.commands
+    assert image_spec.commands[0].name
+    # command.task resolved to an actual class (not left as an unresolved string)
+    assert not isinstance(image_spec.commands[0].task, str)

--- a/tests/test_monai_specs.py
+++ b/tests/test_monai_specs.py
@@ -216,3 +216,35 @@ def test_generate_spec_shape(tmp_path, whitelist_file, overlay_dir, monkeypatch)
     assert cmd["sources"]["image"]["datatype"] == "medimage/nifti-gz-x"
     # sink path rewritten to the frametree store path
     assert cmd["sinks"]["pred"]["path"] == "monai/spleen_ct_segmentation/pred"
+
+
+def test_write_spec_creates_yaml(tmp_path, whitelist_file):
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    path = mm.write_spec(entry, {"name": entry.name, "version": "0.5.3", "commands": []})
+    assert path == mm.spec_path(entry)
+    reloaded = yaml.safe_load(path.read_text())
+    assert reloaded["version"] == "0.5.3"
+
+
+def test_sync_writes_only_changed(tmp_path, whitelist_file, overlay_dir, monkeypatch):
+    import scripts.monai_specs as ms
+
+    monkeypatch.setattr(ms, "get_all_bundles_list",
+                        lambda **kw: [("spleen_ct_segmentation", "0.5.3")])
+    monkeypatch.setattr(
+        ms, "spec_fragment",
+        lambda bundle: {"sources": {}, "sinks": {}, "parameters": {}},
+    )
+    mm = MonaiModels(root=tmp_path, whitelist_path=whitelist_file)
+
+    written = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    assert len(written) == 1
+    assert written[0].is_file()
+    # sync also emitted the committed per-model task module
+    entry = mm.whitelist()[0]._replace(version="0.5.3")
+    assert mm.task_module_path(entry).is_file()
+
+    # Second run: version unchanged -> nothing written
+    written2 = mm.sync(download_bundle=lambda entry: tmp_path / "bundle")
+    assert written2 == []


### PR DESCRIPTION
## Summary

Adds a scheduled generator that turns whitelisted MONAI Model Zoo bundles into pipeline2app XNAT specs, so MONAI models become buildable AIS pipelines.

A `MonaiModels` class (`scripts/monai_specs.py`) that:
- loads a **whitelist** (`scripts/monai_whitelist.yaml`) of models + optional version pins + anatomy placement;
- **fetches** available Model Zoo bundles and latest versions;
- **filters** to the whitelist and **detects** new/updated models vs existing specs;
- for each changed model: downloads the bundle, generates a **committed per-model pydra task module** under `src/australianimagingservice/<modality>/<species>/<region>/monai/<model>.py`, **vendors the bundle beside it**, generates a pipeline2app 2.x `XnatApp` spec (delegating field mapping to `pydra_compose_monai.spec_fragment`, merged with a hand-authored overlay), and writes it under `specs/australian-imaging-service/.../monai/<model>.yaml`.

A scheduled **GitHub Action** (`.github/workflows/monai-sync.yml`) runs the sync weekly and opens a PR with any changed specs + modules for review.

## Key design decisions

- **`command.task` = a committed generated per-model class** (`module:Class`), not a generic task. This is pipeline2app's primary, best-tested task form.
- **The bundle is vendored beside the generated module** (`Path(__file__).parent / "<model>_bundle"`), because pipeline2app imports and introspects `command.task` *eagerly* at spec-load / Dockerfile-generation — so the bundle must be present on the build host, not only inside the final image. This was surfaced by the `XnatApp.load` contract check and drove the vendoring approach.

## Testing

- 15 unit/integration tests in `tests/test_monai_specs.py`, all passing.
- The critical contract test `test_generated_spec_loads_as_xnatapp` runs a full `sync` against a synthetic bundle and asserts `XnatApp.load` resolves `command.task` to the real generated class end-to-end (verified non-vacuous).
- Depends on `pydra-compose-monai >=0.1.3` (adds `spec_fragment`), added to the `test` extras.

## Follow-ups (non-blocking, tracked in the plan's Open items)

- Move vendored bundle **weights to git-lfs** before whitelisting models with large weights (PoC commits them as plain blobs).
- Add a `_download` test covering MONAI's `remove_prefix='monai_'` behavior before expanding the whitelist.
- Auto-generate overlay metadata (currently hand-authored per model).

Design + plan: `docs/superpowers/specs/2026-07-10-monai-spec-generator-design.md`, `docs/superpowers/plans/2026-07-10-monai-model-registry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)